### PR TITLE
travis ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
-  - "3.4"
   - "3.5"
 # command to install dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ python:
   - "3.4"
   - "3.5"
 # command to install dependencies
-install:
-  - pip install -r requirements.txt
+install: "pip install -r requirements.txt"
 # command to run tests
-script: nosetests tests
+script: nosetests
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ python:
   - "3.4"
   - "3.5"
 # command to install dependencies
-install: "pip install -r requirements.txt"
+install:
+  - pip install .
+  - pip install -r requirements.txt
 # command to run tests
 script: nosetests
 sudo: false

--- a/README.rst
+++ b/README.rst
@@ -21,27 +21,22 @@ Important links:
 
 Still using the AP's FTP system for results? Use the Los Angeles Times' `python-elections <https://github.com/datadesk/python-elections>`_ library.
 
-.. image:: https://travis-ci.org/eads/elex.png
-    :target: https://travis-ci.org/eads/elex
+.. image:: https://travis-ci.org/newsdev/elex.png
+    :target: https://travis-ci.org/newsdev/elex
     :alt: Build status
-
 
 .. image:: https://img.shields.io/pypi/dw/elex.svg
     :target: https://pypi.python.org/pypi/elex
     :alt: PyPI downloads
 
-
 .. image:: https://img.shields.io/pypi/v/elex.svg
     :target: https://pypi.python.org/pypi/elex
     :alt: Version
-
 
 .. image:: https://img.shields.io/pypi/l/elex.svg
     :target: https://pypi.python.org/pypi/elex
     :alt: License
 
-
 .. image:: https://img.shields.io/pypi/pyversions/elex.svg
     :target: https://pypi.python.org/pypi/elex
     :alt: Support Python versions
- 

--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,7 @@ Important links:
 * Documentation: http://elex.readthedocs.org/
 * Repository: https://github.com/newsdev/elex/
 * Issues: https://github.com/newsdev/elex/issues
+* Roadmap: https://github.com/newsdev/elex/milestones
 * Demo implementation: https://github.com/nprapps/ap-election-loader
 
 Still using the AP's FTP system for results? Use the Los Angeles Times' `python-elections <https://github.com/datadesk/python-elections>`_ library.

--- a/README.rst
+++ b/README.rst
@@ -24,3 +24,24 @@ Still using the AP's FTP system for results? Use the Los Angeles Times' `python-
 .. image:: https://travis-ci.org/eads/elex.png
     :target: https://travis-ci.org/eads/elex
     :alt: Build status
+
+
+.. image:: https://img.shields.io/pypi/dw/elex.svg
+    :target: https://pypi.python.org/pypi/elex
+    :alt: PyPI downloads
+
+
+.. image:: https://img.shields.io/pypi/v/elex.svg
+    :target: https://pypi.python.org/pypi/elex
+    :alt: Version
+
+
+.. image:: https://img.shields.io/pypi/l/elex.svg
+    :target: https://pypi.python.org/pypi/elex
+    :alt: License
+
+
+.. image:: https://img.shields.io/pypi/pyversions/elex.svg
+    :target: https://pypi.python.org/pypi/elex
+    :alt: Support Python versions
+ 

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
                  'Programming Language :: Python',
                  'Programming Language :: Python :: 2',
                  'Programming Language :: Python :: 2.7',
+                 'Programming Language :: Python :: 3',
                  'Programming Language :: Python :: 3.5',
                  ]
 )

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def read(filename):
 
 setup(
     name='elex',
-    version='0.1.0',
+    version='0.1.1',
     author='Jeremy Bowers',
     author_email='jeremy.bowers@nytimes.com',
     url='https://github.com/newsdev/elex',

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,10 @@ setup(
     install_requires=reqs,
     classifiers=['Development Status :: 3 - Alpha',
                  'Intended Audience :: Developers',
+                 'Topic :: Software Development :: Libraries :: Python Modules',
                  'Programming Language :: Python',
-                 'Topic :: Software Development :: Libraries :: Python Modules']
+                 'Programming Language :: Python :: 2',
+                 'Programming Language :: Python :: 2.7',
+                 'Programming Language :: Python :: 3.5',
+                 ]
 )


### PR DESCRIPTION
add travis configuration and build badge

we'll still need to set up the project on travis-ci's site; I don't have the permission to do that for newsdev. @jeremyjbowers if you can please make me a repo admin, I can do it. But it's working on my fork (https://github.com/eads/elex/blob/711c3fe035db39ecf4e797d50e0f6edcddd377b0/README.rst).

closes #101 