### PR TITLE
Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.gitignore
+.travis.yml
+AUTHORS.rst
+CHANGELOG.rst
+docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.5
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+COPY . /usr/src/app
+RUN pip install --no-cache-dir ./
+ENTRYPOINT ["/usr/local/bin/elex"]


### PR DESCRIPTION
I've added a (should be) working Dockerfile for ELEX. This provides users the ability to install ELEX without local conflicts or really without installing Python at all. Eventually you may want to use this as the basis for an [automated build](https://docs.docker.com/docker-hub/builds/), but for now it's buildable from within the source directory.

```bash
docker build -t elex .
docker run --rm elex --help
```

In order to read to or write from files on disk, users will need to use [Docker volumes](https://docs.docker.com/engine/userguide/dockervolumes/).
