### PR TITLE
add to README that API key is required

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 ELEX
 ====
 
-Get database-ready election results from the Associated Press Election API v2.0.
+Get database-ready election results from the Associated Press Election API v2.0. An API key from AP is required.
 
 Designed to be fast, friendly, and largely agnostic to stack/language/database choice. Basic usage is
 as simple as:


### PR DESCRIPTION
Making it clear that to use elex one needs an API key from Associated Press.