### PR TITLE
use nose2-cprof for profiling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
 install:
   - travis_retry pip install .
   - travis_retry pip install -r requirements.txt
+  - travis_retry pip install -e git+https://github.com/peteut/nose2-cprof.git#egg=nose2cprof
 # command to run tests
 script: python -m nose2.__main__ -v
 sudo: false

--- a/nose2.cfg
+++ b/nose2.cfg
@@ -1,0 +1,2 @@
+[unittest]
+plugins = nose2cprof.cprof

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
             'elex = elex.cli:main',
         ],
     },
+    dependency_links=['http://github.com/peteut/nose2-cprof/tarball/master#egg=nose2cprof'],
     license="Apache License 2.0",
     keywords='election race candidate democracy news associated press',
     install_requires=reqs,


### PR DESCRIPTION
closes #112 (hopefully)

this is accomplished by installing and loading the nose2-cprof plugin (https://github.com/peteut/nose2-cprof/) which supersedes the old hotshot plugin, which hasn't worked in ages. probably worth poking to see if it could go into nose2.

