### PR TITLE
0134 refactor requests

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -7,3 +7,4 @@ These individuals have contributed code, tests, documentation, and troubleshooti
 * Livia Labate
 * Wilson Andrews
 * Eric Buth
+* Juan Elosua

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ New York Times
 News
 ====
 
-* `NPR and The New York Times teamed up to make election reporting faster <http://www.poynter.org/news/mediawire/388642/npr-and-the-new-york-times-teamed-up-to-make-election-reporting-faster/>`_, Ben Mullins, Poynter
+* `NPR and The New York Times teamed up to make election reporting faster <http://www.poynter.org/news/mediawire/388642/npr-and-the-new-york-times-teamed-up-to-make-election-reporting-faster/>`_, Benjamin Mullin, Poynter
 * `Introducing Elex, A Tool To Make Election Coverage Better For Everyone <https://source.opennews.org/en-US/articles/introducing-elex-tool-make-election-coverage-bette/>`_, Jeremy Bowers and David Eads, Source
 
 Using the FTP system?

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,26 @@
 ELEX
 ====
 
+.. image:: https://travis-ci.org/newsdev/elex.png
+    :target: https://travis-ci.org/newsdev/elex
+    :alt: Build status
+
+.. image:: https://img.shields.io/pypi/dw/elex.svg
+    :target: https://pypi.python.org/pypi/elex
+    :alt: PyPI downloads
+
+.. image:: https://img.shields.io/pypi/v/elex.svg
+    :target: https://pypi.python.org/pypi/elex
+    :alt: Version
+
+.. image:: https://img.shields.io/pypi/l/elex.svg
+    :target: https://github.com/newsdev/elex/blob/master/LICENSE
+    :alt: License
+
+.. image:: https://img.shields.io/pypi/pyversions/elex.svg
+    :target: https://pypi.python.org/pypi/elex
+    :alt: Support Python versions
+
 Get database-ready election results from the Associated Press Election API v2.0.
 
 Elex is designed to be fast, friendly, and largely agnostic to stack/language/database choice. Basic usage is
@@ -43,26 +63,3 @@ Using the FTP system?
 =====================
 
 Use the Los Angeles Times' `python-elections <https://github.com/datadesk/python-elections>`_ library.
-
-Status
-======
-
-.. image:: https://travis-ci.org/newsdev/elex.png
-    :target: https://travis-ci.org/newsdev/elex
-    :alt: Build status
-
-.. image:: https://img.shields.io/pypi/dw/elex.svg
-    :target: https://pypi.python.org/pypi/elex
-    :alt: PyPI downloads
-
-.. image:: https://img.shields.io/pypi/v/elex.svg
-    :target: https://pypi.python.org/pypi/elex
-    :alt: Version
-
-.. image:: https://img.shields.io/pypi/l/elex.svg
-    :target: https://github.com/newsdev/elex/blob/master/LICENSE
-    :alt: License
-
-.. image:: https://img.shields.io/pypi/pyversions/elex.svg
-    :target: https://pypi.python.org/pypi/elex
-    :alt: Support Python versions

--- a/README.rst
+++ b/README.rst
@@ -17,9 +17,35 @@ Important links:
 * Repository: https://github.com/newsdev/elex/
 * Issues: https://github.com/newsdev/elex/issues
 * Roadmap: https://github.com/newsdev/elex/milestones
-* Demo implementation: https://github.com/nprapps/ap-election-loader
 
-Still using the AP's FTP system for results? Use the Los Angeles Times' `python-elections <https://github.com/datadesk/python-elections>`_ library.
+Elex projects and implementations
+=================================
+
+NPR
+---
+
+* `NPR loader <https://github.com/nprapps/ap-election-loader>`_: A simple reference data loader for PostgreSQL.
+
+New York Times
+--------------
+
+* `New York Times loader <https://github.com/newsdev/elex-loader>`_: A more sophisticated data loader for PostgreSQL.
+* `New York Times Deja Vu <https://github.com/newsdev/ap-deja-vu>`_: A webservice to replay JSON captured during an election.
+* `New York Times Elex Admin <https://github.com/newsdev/elex-admin>`_: An admin interface for Elex data loaded with the New York Times loader written in Flask.
+
+News
+====
+
+* `NPR and The New York Times teamed up to make election reporting faster <http://www.poynter.org/news/mediawire/388642/npr-and-the-new-york-times-teamed-up-to-make-election-reporting-faster/>`_, Ben Mullins, Poynter
+* `Introducing Elex, A Tool To Make Election Coverage Better For Everyone <https://source.opennews.org/en-US/articles/introducing-elex-tool-make-election-coverage-bette/>`_, Jeremy Bowers and David Eads, Source
+
+Using the FTP system?
+=====================
+
+Use the Los Angeles Times' `python-elections <https://github.com/datadesk/python-elections>`_ library.
+
+Status
+======
 
 .. image:: https://travis-ci.org/newsdev/elex.png
     :target: https://travis-ci.org/newsdev/elex

--- a/README.rst
+++ b/README.rst
@@ -59,8 +59,8 @@ Elex projects and implementations
 News
 ====
 
-* `NPR and The New York Times teamed up to make election reporting faster <http://www.poynter.org/news/mediawire/388642/npr-and-the-new-york-times-teamed-up-to-make-election-reporting-faster/>`_, Benjamin Mullin, Poynter
 * `Introducing Elex, A Tool To Make Election Coverage Better For Everyone <https://source.opennews.org/en-US/articles/introducing-elex-tool-make-election-coverage-bette/>`_, Jeremy Bowers and David Eads, Source
+* `NPR and The New York Times teamed up to make election reporting faster <http://www.poynter.org/news/mediawire/388642/npr-and-the-new-york-times-teamed-up-to-make-election-reporting-faster/>`_, Benjamin Mullin, Poynter
 
 Using the FTP system?
 =====================

--- a/README.rst
+++ b/README.rst
@@ -41,17 +41,20 @@ Important links:
 Elex projects and implementations
 =================================
 
-NPR
----
+**NPR**
+
 
 * `NPR loader <https://github.com/nprapps/ap-election-loader>`_: A simple reference data loader for PostgreSQL.
 
-New York Times
---------------
+**New York Times**
 
 * `New York Times loader <https://github.com/newsdev/elex-loader>`_: A more sophisticated data loader for PostgreSQL.
 * `New York Times Deja Vu <https://github.com/newsdev/ap-deja-vu>`_: A webservice to replay JSON captured during an election.
 * `New York Times Elex Admin <https://github.com/newsdev/elex-admin>`_: An admin interface for Elex data loaded with the New York Times loader written in Flask.
+
+**Experimental**
+
+* `node-elex-admin <https://github.com/eads/node-elex-admin>`_: Incomplete node-based admin interface.
 
 News
 ====

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -28,6 +28,16 @@ To get detailed information about performance, run the tests with the --profile 
 
     nose2 tests --profile
 
+Testing API request limit
+=========================
+
+You can test the API request limit, but only by setting an environment variable. Use with extreme
+care.
+
+.. code:: bash
+
+    AP_RUN_QUOTA_TEST=1 nose2 tests.test_ap_quota
+
 Authors
 =======
 

--- a/elex/api/api.py
+++ b/elex/api/api.py
@@ -748,7 +748,8 @@ class Election(APElection):
         :param **params:
             A dict of optional parameters to be included in API request.
         """
-        return utils.api_request(path, **params)
+        self._response = utils.api_request(path, **params)
+        return self._response.json()
 
     def get_uniques(self, candidate_reporting_units):
         """

--- a/elex/api/utils.py
+++ b/elex/api/utils.py
@@ -57,7 +57,7 @@ def api_request(path, **params):
     A properly formatted request:
     * Modifies the BASE_URL with a path.
     * Contains an API_KEY.
-    * Returns JSON.
+    * Returns a response object.
 
     :param **params:
         Extra parameters to pass to `requests`.
@@ -73,6 +73,5 @@ def api_request(path, **params):
 
     params['format'] = 'json'
     response = requests.get(elex.BASE_URL + path, params=params)
-    payload = response.json()
-    write_recording(payload)
-    return payload
+    write_recording(response.json())
+    return response

--- a/elex/api/utils.py
+++ b/elex/api/utils.py
@@ -77,10 +77,11 @@ def api_request(path, **params):
     if response.ok:
         write_recording(response.json())
 
+    # When response is 403, take emergency action and write to stderr
     if response.status_code == 403:
         messagedom = parseString(response.content)
         message = messagedom.getElementsByTagName('Message')[0].childNodes[0].data
-        print('ELEX ERROR: %s' % message, file=sys.stderr)
+        print('ELEX ERROR: %s (url: %s)' % (message, response.url), file=sys.stderr)
 
     return response
 

--- a/elex/api/utils.py
+++ b/elex/api/utils.py
@@ -2,6 +2,7 @@
 Utility functions to record raw election results and handle low-level HTTP interaction with the
 Associated Press Election API.
 """
+from __future__ import print_function
 import datetime
 import elex
 import json
@@ -11,7 +12,7 @@ import sys
 import time
 
 from pymongo import MongoClient
-
+from xml.dom.minidom import parseString
 
 class UnicodeMixin(object):
     """
@@ -73,5 +74,13 @@ def api_request(path, **params):
 
     params['format'] = 'json'
     response = requests.get(elex.BASE_URL + path, params=params)
-    write_recording(response.json())
+    if response.ok:
+        write_recording(response.json())
+
+    if response.status_code == 403:
+        messagedom = parseString(response.content)
+        message = messagedom.getElementsByTagName('Message')[0].childNodes[0].data
+        print('ELEX ERROR: %s' % message, file=sys.stderr)
+
     return response
+

--- a/elex/cli/app.py
+++ b/elex/cli/app.py
@@ -5,6 +5,7 @@ from cement.ext.ext_logging import LoggingLogHandler
 from elex import __version__ as VERSION
 from elex.cli.hooks import add_election_hook
 from elex.cli.decorators import require_date_argument, require_ap_api_key
+from elex.api.api import Elections
 
 LOG_FORMAT = '%(asctime)s (%(levelname)s) %(namespace)s (v{0}) : %(message)s'.format(VERSION)
 
@@ -125,7 +126,7 @@ class ElexBaseController(CementBaseController):
         Initialize reporting units
         """
         self.app.log.info('Getting election list')
-        elections = self.app.election.get_elections(datafile=self.app.pargs.data_file)
+        elections = Elections().get_elections(datafile=self.app.pargs.data_file)
         self.app.render(elections)
 
     @expose(help="Get the next election (if date is specified, will be relative to that date, otherwise will use today's date)")
@@ -135,7 +136,7 @@ class ElexBaseController(CementBaseController):
         Initialize reporting units
         """
         self.app.log.info('Getting next election')
-        election = self.app.election.get_next_election(datafile=self.app.pargs.data_file, electiondate=self.app.pargs.date[0])
+        election = Elections().get_next_election(datafile=self.app.pargs.data_file, electiondate=self.app.pargs.date[0])
         self.app.render(election)
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,6 @@
-import json
 import unittest
 
-from elex.api import api
+from elex.api import api, utils
 
 
 class ElectionResultsTestCase(unittest.TestCase):
@@ -17,3 +16,14 @@ class ElectionResultsTestCase(unittest.TestCase):
         self.races = e.races
         self.reporting_units = e.reporting_units
         self.results = e.results
+
+
+class ElectionNetworkTestCase(unittest.TestCase):
+    def setUp(self, **kwargs):
+        """
+        Cache all responses to allow for single assertion per test without
+        exceeding the API request limit.
+        """
+        self.nonexistent_response = utils.api_request('/1965-01-01')
+        self.nonexistent_param_response = utils.api_request('/', foo='bar')
+        self.bad_date_response = utils.api_request('/9999-99-99')

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,9 @@
 import unittest
 
 from elex.api import api, utils
+from time import sleep
+
+API_MESSAGE = "We require that you export AP_API_KEY in your environment in order to test AP connectivity."
 
 
 class ElectionResultsTestCase(unittest.TestCase):
@@ -18,12 +21,8 @@ class ElectionResultsTestCase(unittest.TestCase):
         self.results = e.results
 
 
-class ElectionNetworkTestCase(unittest.TestCase):
-    def setUp(self, **kwargs):
-        """
-        Cache all responses to allow for single assertion per test without
-        exceeding the API request limit.
-        """
-        self.nonexistent_response = utils.api_request('/1965-01-01')
-        self.nonexistent_param_response = utils.api_request('/', foo='bar')
-        self.bad_date_response = utils.api_request('/9999-99-99')
+class NetworkTestCase(unittest.TestCase):
+    def api_request(self, *args, **kwargs):
+        response = utils.api_request(*args, **kwargs)
+        sleep(10)
+        return response

--- a/tests/test_ap_network.py
+++ b/tests/test_ap_network.py
@@ -3,31 +3,40 @@ import os
 import unittest
 
 from elex.api import utils
+from tests import ElectionNetworkTestCase
 
-class APNetworkTestCase(unittest.TestCase):
+class APNetworkTestCase(ElectionNetworkTestCase):
 
     message = "We require that you export AP_API_KEY in your environment in order to test AP connectivity."
 
     @unittest.skipUnless(os.environ.get('AP_API_KEY', None), message)
-    def test_bad_date(self):
-        r = utils.api_request('/9999-99-99')
-        self.assertTrue('errorCode' in r)
-        self.assertTrue('errorMessage' in r)
-        self.assertEqual(r['errorCode'], 400)
-        self.assertEqual(r['errorMessage'], 'String was not recognized as a valid DateTime.')
-        self.assertFalse('races' in r)
+    def test_bad_date_error_code(self):
+        self.assertEqual(self.bad_date_response.status_code, 400)
 
     @unittest.skipUnless(os.environ.get('AP_API_KEY', None), message)
-    def test_nonexistent_date(self):
-        r = utils.api_request('/1965-01-01')
-        self.assertTrue('races' in r)
-        self.assertEqual(len(r['races']), 0)
+    def test_bad_date_error_message(self):
+        self.assertEqual(self.bad_date_response.reason, 400)
 
-    @unittest.skipUnless(os.environ.get('AP_API_KEY', None), message)
-    def test_nonexistent_param(self):
-        r = utils.api_request('/', foo='bar')
-        self.assertTrue('errorCode' in r)
-        self.assertTrue('errorMessage' in r)
-        self.assertEqual(r['errorCode'], 400)
-        self.assertEqual(r['errorMessage'], 'Specified parameter(s) \'foo\' is invalid')
-        self.assertFalse('races' in r)
+        #r = response.json()
+        #self.assertTrue('errorCode' in r)
+        #self.assertTrue('errorMessage' in r)
+        #self.assertEqual(r['errorCode'], 400)
+        #self.assertEqual(r['errorMessage'], 'String was not recognized as a valid DateTime.')
+        #self.assertFalse('races' in r)
+
+    #@unittest.skipUnless(os.environ.get('AP_API_KEY', None), message)
+    #def test_nonexistent_date(self):
+        #response = utils.api_request('/1965-01-01')
+        #r = response.json()
+        #self.assertTrue('races' in r)
+        #self.assertEqual(len(r['races']), 0)
+
+    #@unittest.skipUnless(os.environ.get('AP_API_KEY', None), message)
+    #def test_nonexistent_param(self):
+        #response = utils.api_request('/', foo='bar')
+        #r = response.json()
+        #self.assertTrue('errorCode' in r)
+        #self.assertTrue('errorMessage' in r)
+        #self.assertEqual(r['errorCode'], 400)
+        #self.assertEqual(r['errorMessage'], 'Specified parameter(s) \'foo\' is invalid')
+        #self.assertFalse('races' in r)

--- a/tests/test_ap_network.py
+++ b/tests/test_ap_network.py
@@ -1,42 +1,35 @@
-import json
 import os
 import unittest
 
-from elex.api import utils
-from tests import ElectionNetworkTestCase
+from . import NetworkTestCase, API_MESSAGE
 
-class APNetworkTestCase(ElectionNetworkTestCase):
 
-    message = "We require that you export AP_API_KEY in your environment in order to test AP connectivity."
+class APNetworkTestCase(NetworkTestCase):
 
-    @unittest.skipUnless(os.environ.get('AP_API_KEY', None), message)
+    @unittest.skipUnless(os.environ.get('AP_API_KEY', None), API_MESSAGE)
     def test_bad_date_error_code(self):
-        self.assertEqual(self.bad_date_response.status_code, 400)
+        self.assertEqual(self.api_request('/9999-99-99').status_code, 400)
 
-    @unittest.skipUnless(os.environ.get('AP_API_KEY', None), message)
+    @unittest.skipUnless(os.environ.get('AP_API_KEY', None), API_MESSAGE)
     def test_bad_date_error_message(self):
-        self.assertEqual(self.bad_date_response.reason, 400)
+        bad_date_response = self.api_request('/9999-99-99')
+        data = bad_date_response.json()
+        self.assertEqual(data['errorMessage'], 'String was not recognized as a valid DateTime.')
 
-        #r = response.json()
-        #self.assertTrue('errorCode' in r)
-        #self.assertTrue('errorMessage' in r)
-        #self.assertEqual(r['errorCode'], 400)
-        #self.assertEqual(r['errorMessage'], 'String was not recognized as a valid DateTime.')
-        #self.assertFalse('races' in r)
+    @unittest.skipUnless(os.environ.get('AP_API_KEY', None), API_MESSAGE)
+    def test_bad_date_fields(self):
+        bad_date_response = self.api_request('/9999-99-99')
+        data = bad_date_response.json()
+        keys = data.keys()
+        self.assertTrue('errorMessage' in keys and 'errorCode' in keys)
 
-    #@unittest.skipUnless(os.environ.get('AP_API_KEY', None), message)
-    #def test_nonexistent_date(self):
-        #response = utils.api_request('/1965-01-01')
-        #r = response.json()
-        #self.assertTrue('races' in r)
-        #self.assertEqual(len(r['races']), 0)
+    @unittest.skipUnless(os.environ.get('AP_API_KEY', None), API_MESSAGE)
+    def test_nonexistent_date(self):
+        nonexistent_date_response = self.api_request('/1965-01-01')
+        data = nonexistent_date_response.json()
+        self.assertEqual(len(data['races']), 0)
 
-    #@unittest.skipUnless(os.environ.get('AP_API_KEY', None), message)
-    #def test_nonexistent_param(self):
-        #response = utils.api_request('/', foo='bar')
-        #r = response.json()
-        #self.assertTrue('errorCode' in r)
-        #self.assertTrue('errorMessage' in r)
-        #self.assertEqual(r['errorCode'], 400)
-        #self.assertEqual(r['errorMessage'], 'Specified parameter(s) \'foo\' is invalid')
-        #self.assertFalse('races' in r)
+    @unittest.skipUnless(os.environ.get('AP_API_KEY', None), API_MESSAGE)
+    def test_nonexistent_param(self):
+        nonexistent_param_response = self.api_request('/', foo='bar')
+        self.assertEqual(nonexistent_param_response.status_code, 400)

--- a/tests/test_ap_quota.py
+++ b/tests/test_ap_quota.py
@@ -1,0 +1,18 @@
+import os
+import unittest
+
+from elex.api import utils
+from . import API_MESSAGE
+
+AP_API_LIMIT = 20
+QUOTA_MESSAGE = 'You must set AP_RUN_QUOTA_TEST=1 in your environment to run the quota test.'
+
+
+class APQuotaTestCase(unittest.TestCase):
+
+    @unittest.skipUnless(os.environ.get('AP_API_KEY', None), API_MESSAGE)
+    @unittest.skipUnless(os.environ.get('AP_RUN_QUOTA_TEST', None), QUOTA_MESSAGE)
+    def test_quota_status_code(self):
+        for i in range(AP_API_LIMIT):
+            response = utils.api_request('/')
+        self.assertEqual(response.status_code, 403)


### PR DESCRIPTION
Lots of weird tweaks found in the process of changing over to a response-based api wrapper. In addition to the task at hand:

* Throttle network tests
* Add opt-in quota limit test
* Catch and alert quota limit errors in api_request