### PR TITLE
Add instructions for setting up on windows

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -23,6 +23,8 @@ On Windows machines, use ``setx`` instead
 
     setx AP_API_KEY=<MY_AP_API_KEY>
 
+.. note:: ``Setx`` sets a permanent user level environment variable. To set a machine level variable use ``\m`` option
+
 Optional requirements
 =====================
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -17,6 +17,12 @@ Set your AP API key:
 
     export AP_API_KEY=<MY_AP_API_KEY>
 
+On Windows machines, use ``setx`` instead
+
+.. code:: bat
+
+    setx AP_API_KEY=<MY_AP_API_KEY>
+
 Optional requirements
 =====================
 


### PR DESCRIPTION
Elex works on windows. Had to set an environment variable using setx. Added instructions for that.

The instructions work on `cmd` as well as `powerShell`