### PR TITLE
Put pep8 and pyflakes dependencies in the right place

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
 install:
   - travis_retry pip install .
   - travis_retry pip install -r requirements.txt
+  - travis_retry pip install pep8 pyflakes
   - travis_retry pip install -e git+https://github.com/peteut/nose2-cprof.git#egg=nose2cprof
 # command to run tests
 script:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,3 @@ clint==0.5.1
 pymongo==2.8
 python-dateutil==2.2
 requests==2.9.1
-pyflakes
-pep8


### PR DESCRIPTION
I screwed up with my early PRs by including pep and pyflakes in requirements.txt, which also shipped them with PyPI releases. Like Sphinx, it should only be installed by developers. Travis needs it too, though, so I put a new install in there.