### PR TITLE
0234 minimize requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
 # command to run tests
 script:
   - pyflakes elex
-  - pep8 elex
+  - pep8 --max-line-length=120 elex
   - pyflakes tests
   - pep8 tests
   - python -m nose2.__main__ -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ script:
   - pyflakes elex
   - pep8 --max-line-length=120 elex
   - pyflakes tests
-  - pep8 tests
+  - pep8 --max-line-length=120 tests
   - python -m nose2.__main__ -v
 sudo: false

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -4,62 +4,64 @@ Command line interface
 
 ::
 
-  commands:
+    commands:
 
-    ballot-measures
-      Get ballot positions (also known as ballot issues)
+      ballot-measures
+        Get ballot measures
 
-    candidate-reporting-units
-      Get candidate reporting units (without results)
+      candidate-reporting-units
+        Get candidate reporting units (without results)
 
-    candidates
-      Get candidates
+      candidates
+        Get candidates
 
-    delegates
-      Get all delegate reports
+      clear-delegate-cache
+        Clear the delegate report ID cache.
 
-    elections
-      Get list of available elections
+      delegates
+        Get all delegate reports
 
-    next-election
-      Get the next election (if date is specified, will be relative to that date, otherwise will use today's date)
+      elections
+        Get list of available elections
 
-    races
-      Get races
+      next-election
+        Get the next election (if date is specified, will be relative to that date, otherwise will use today's date)
 
-    reporting-units
-      Get reporting units
+      races
+        Get races
 
-    results
-      Get results
+      reporting-units
+        Get reporting units
 
-  positional arguments:
-    date                  Election date (e.g. "2015-11-03"; most common date
-                          formats accepted).
+      results
+        Get results
 
-  optional arguments:
-    -h, --help            show this help message and exit
-    --debug               toggle debug output
-    --quiet               suppress all output
-    -o {json,csv}         output format (default: csv)
-    -t, --test            Use testing API calls
-    -n, --not-live        Do not use live data API calls
-    -d DATA_FILE, --data-file DATA_FILE
-                          Specify data file instead of making HTTP request when
-                          using election commands like `elex results` and `elex
-                          races`.
-    --delegate-sum-file DELEGATE_SUM_FILE
-                          Specify delegate sum report file instead of making
-                          HTTP request when using `elex delegates`
-    --delegate-super-file DELEGATE_SUPER_FILE
-                          Specify delegate super report file instead of making
-                          HTTP request when using `elex delegates`
-    --local-only          Limit results to local-level results only, ignoring
-                          national races like President, House/Senate and
-                          Governor
-    --format-json         Pretty print JSON when using `-o json`.
-    --results-level       Specify reporting level when using `elex results`, 
-                          such as `district` or `state`
-    --set-zero-counts     Override results with zeros; omits the winner
-                          indicator.
-    -v, --version         Show program's version number and exit
+    positional arguments:
+      date                  Election date (e.g. "2015-11-03"; most common date
+                            formats accepted).
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      --debug               toggle debug output
+      --quiet               suppress all output
+      -o {json,csv}         output format (default: csv)
+      -t, --test            Use testing API calls
+      -n, --not-live        Do not use live data API calls
+      -d DATA_FILE, --data-file DATA_FILE
+                            Specify data file instead of making HTTP request when
+                            using election commands like `elex results` and `elex
+                            races`.
+      --delegate-sum-file DELEGATE_SUM_FILE
+                            Specify delegate sum report file instead of making
+                            HTTP request when using `elex delegates`
+      --delegate-super-file DELEGATE_SUPER_FILE
+                            Specify delegate super report file instead of making
+                            HTTP request when using `elex delegates`
+      --format-json         Pretty print JSON when using `-o json`.
+      -v, --version         show program's version number and exit
+      --results-level RESULTS_LEVEL
+                            Specify reporting level for results
+      --set-zero-counts     Override results with zeros; omits the winner
+                            indicator.Sets the vote, delegate, and reporting
+                            precinct counts to zero.
+      --local-only          Limit results to local-level results only.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,0 +1,40 @@
+*************
+Configuration
+*************
+
+The following environment variables may be set:
+
+::
+
+    export API_VERSION='v2'
+    export BASE_URL='http://api.ap.org/v2'
+    export API_KEY='<<YOURAPIKEY>>'
+    export ELEX_DELEGATE_REPORT_ID_CACHE_FILE='/tmp/elex-cache'
+    export ELEX_RECORDING='flat'
+    export ELEX_RECORDING_DIR='/tmp/elex-recording'
+
+API_VERSION
+===========
+
+The AP API version. You should never need to change this.
+
+BASE_URL
+========
+
+Use a different base url for API requests. Helpful if running a mirror or archive of raw AP data like `Elex Deja Vu <https://github.com/newsdev/ap-deja-vu>`_.
+
+API_KEY
+=======
+
+Your API key. Must be set.
+
+
+ELEX_DELEGATE_REPORT_ID_CACHE_FILE
+==================================
+
+To cut down on requests for a rarely changing ID, Elex caches this ID in a file stored in a temporary directory. You can override the default temporary directory (which is found in an OS-agnostic way with the Python tempfile library) by specifying this environment variable. You shouldn't need to set this in most cases.
+
+ELEX_RECORDING, ELEX_RECORDING_DIR
+==================================
+
+Configure full data recording. See :doc:`recording`.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,7 @@ Table of contents
     tutorial
     cli
     api
+    configuration
     recording
     recipes
     contributing

--- a/elex/__init__.py
+++ b/elex/__init__.py
@@ -3,6 +3,6 @@ import pkg_resources
 
 
 __version__ = pkg_resources.get_distribution('elex').version
-VERSION = os.environ.get('AP_API_VERSION', 'v2')
-BASE_URL = os.environ.get('AP_API_BASE_URL', 'http://api.ap.org/{0}'.format(VERSION))
+API_VERSION = os.environ.get('AP_API_VERSION', 'v2')
+BASE_URL = os.environ.get('AP_API_BASE_URL', 'http://api.ap.org/{0}'.format(API_VERSION))
 API_KEY = os.environ.get('AP_API_KEY', None)

--- a/elex/__init__.py
+++ b/elex/__init__.py
@@ -4,5 +4,5 @@ import pkg_resources
 
 __version__ = pkg_resources.get_distribution('elex').version
 VERSION = os.environ.get('AP_API_VERSION', 'v2')
-BASE_URL = os.environ.get('AP_API_BASE_URL', 'http://api.ap.org/%s' % VERSION)
+BASE_URL = os.environ.get('AP_API_BASE_URL', 'http://api.ap.org/{0}'.format(VERSION))
 API_KEY = os.environ.get('AP_API_KEY', None)

--- a/elex/__init__.py
+++ b/elex/__init__.py
@@ -1,8 +1,11 @@
 import os
 import pkg_resources
+import tempfile
 
 
 __version__ = pkg_resources.get_distribution('elex').version
 API_VERSION = os.environ.get('AP_API_VERSION', 'v2')
 BASE_URL = os.environ.get('AP_API_BASE_URL', 'http://api.ap.org/{0}'.format(API_VERSION))
 API_KEY = os.environ.get('AP_API_KEY', None)
+DEFAULT_TEMPDIR = os.path.join(tempfile.gettempdir(), 'elex-cache')
+DELEGATE_REPORT_ID_CACHE_FILE = os.environ.get('ELEX_DELEGATE_REPORT_ID_CACHE_FILE', DEFAULT_TEMPDIR)

--- a/elex/__init__.py
+++ b/elex/__init__.py
@@ -4,8 +4,5 @@ import pkg_resources
 
 __version__ = pkg_resources.get_distribution('elex').version
 VERSION = os.environ.get('AP_API_VERSION', 'v2')
-BASE_URL = "%s/elections" % os.environ.get(
-    'AP_API_BASE_URL',
-    'http://api.ap.org/%s' % VERSION
-)
+BASE_URL = os.environ.get('AP_API_BASE_URL', 'http://api.ap.org/%s' % VERSION)
 API_KEY = os.environ.get('AP_API_KEY', None)

--- a/elex/api/delegates.py
+++ b/elex/api/delegates.py
@@ -3,15 +3,12 @@
 This module contains the primary :class:`DelegateLoad` class for handling a
 single load of AP delegate counts and methods necessary to obtain them.
 """
-import os
 import json
 import percache
-import tempfile
 
+from elex import DELEGATE_REPORT_ID_CACHE_FILE
 from elex.api import utils
 from collections import OrderedDict
-
-DELEGATE_REPORT_ID_CACHE_FILE = os.path.join(tempfile.gettempdir(), 'elex-cache2')
 
 cache = percache.Cache(DELEGATE_REPORT_ID_CACHE_FILE, livesync=True)
 

--- a/elex/api/delegates.py
+++ b/elex/api/delegates.py
@@ -26,6 +26,13 @@ def _get_reports(params={}):
         return []
 
 
+def clear_delegate_cache():
+    """
+    Delete the delegate cache file
+    """
+    cache.clear()
+
+
 class CandidateDelegateReport(utils.UnicodeMixin):
     """
     'level': 'state',

--- a/elex/api/models.py
+++ b/elex/api/models.py
@@ -856,7 +856,7 @@ class Election(APElection):
         :param **params:
             A dict of optional parameters to be included in API request.
         """
-        self._response = utils.api_request('/elections/%s' % path, **params)
+        self._response = utils.api_request('/elections/{0}'.format(path), **params)
         return self._response.json()
 
     def get_uniques(self, candidate_reporting_units):

--- a/elex/api/models.py
+++ b/elex/api/models.py
@@ -759,7 +759,7 @@ class Elections():
             If datafile is specified, use instead of making an API call.
         """
         if not datafile:
-            elections = list(utils.api_request('/').json().get('elections'))
+            elections = list(utils.api_request('/elections').json().get('elections'))
         else:
             with open(datafile) as f:
                 elections = list(json.load(f).get('elections'))
@@ -856,7 +856,7 @@ class Election(APElection):
         :param **params:
             A dict of optional parameters to be included in API request.
         """
-        self._response = utils.api_request(path, **params)
+        self._response = utils.api_request('/elections/%s' % path, **params)
         return self._response.json()
 
     def get_uniques(self, candidate_reporting_units):

--- a/elex/api/utils.py
+++ b/elex/api/utils.py
@@ -104,3 +104,10 @@ def api_request(path, **params):
             file=sys.stderr
         )
     return response
+
+
+def clear_delegate_cache():
+    """
+    Delete the delegate cache file
+    """
+    os.remove(elex.DELEGATE_REPORT_ID_CACHE_FILE)

--- a/elex/api/utils.py
+++ b/elex/api/utils.py
@@ -104,10 +104,3 @@ def api_request(path, **params):
             file=sys.stderr
         )
     return response
-
-
-def clear_delegate_cache():
-    """
-    Delete the delegate cache file
-    """
-    os.remove(elex.DELEGATE_REPORT_ID_CACHE_FILE)

--- a/elex/cli/app.py
+++ b/elex/cli/app.py
@@ -223,6 +223,9 @@ Sets the vote, delegate, and reporting precinct counts to zero.',
                 delsum_datafile=self.app.pargs.delegate_sum_file
             )
         else:
+            self.app.log.debug(
+                'Elex delegate cache location: {0}'.format(DELEGATE_REPORT_ID_CACHE_FILE)
+            )
             report = DelegateReport()
 
         self.app.render(report.candidate_objects)

--- a/elex/cli/app.py
+++ b/elex/cli/app.py
@@ -1,6 +1,6 @@
 from elex.api import Elections
 from elex.api import DelegateReport
-from elex.api.utils import clear_delegate_cache
+from elex.api.delegates import clear_delegate_cache
 from elex import DELEGATE_REPORT_ID_CACHE_FILE
 from elex import __version__ as VERSION
 from cement.core.foundation import CementApp

--- a/elex/cli/app.py
+++ b/elex/cli/app.py
@@ -1,5 +1,7 @@
 from elex.api import Elections
 from elex.api import DelegateReport
+from elex.api.utils import clear_delegate_cache
+from elex import DELEGATE_REPORT_ID_CACHE_FILE
 from elex import __version__ as VERSION
 from cement.core.foundation import CementApp
 from elex.cli.hooks import add_election_hook
@@ -242,6 +244,11 @@ relative to that date, otherwise will use today's date)")
             electiondate=electiondate
         )
         self.app.render(election)
+
+    @expose(help="Clear the delegate report ID cache.")
+    def clear_delegate_cache(self):
+        self.app.log.info('Deleting delegate report ID cache ({0})'.format(DELEGATE_REPORT_ID_CACHE_FILE))
+        clear_delegate_cache()
 
 
 class ElexApp(CementApp):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 cement==2.6.2
 clint==0.5.1
+percache==0.3.0
 pymongo==2.8
 python-dateutil==2.2
 requests==2.9.1

--- a/tests/test_ap_network.py
+++ b/tests/test_ap_network.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 
+from time import sleep
 from . import NetworkTestCase, API_MESSAGE
 
 
@@ -8,11 +9,13 @@ class APNetworkTestCase(NetworkTestCase):
 
     @unittest.skipUnless(os.environ.get('AP_API_KEY', None), API_MESSAGE)
     def test_bad_date_error_code(self):
-        self.assertEqual(self.api_request('/9999-99-99').status_code, 400)
+        sleep(5)
+        self.assertEqual(self.api_request('/elections/9999-99-99').status_code, 400)
 
     @unittest.skipUnless(os.environ.get('AP_API_KEY', None), API_MESSAGE)
     def test_bad_date_error_message(self):
-        bad_date_response = self.api_request('/9999-99-99')
+        sleep(5)
+        bad_date_response = self.api_request('/elections/9999-99-99')
         data = bad_date_response.json()
         self.assertEqual(
             data['errorMessage'],
@@ -21,18 +24,21 @@ class APNetworkTestCase(NetworkTestCase):
 
     @unittest.skipUnless(os.environ.get('AP_API_KEY', None), API_MESSAGE)
     def test_bad_date_fields(self):
-        bad_date_response = self.api_request('/9999-99-99')
+        sleep(5)
+        bad_date_response = self.api_request('/elections/9999-99-99')
         data = bad_date_response.json()
         keys = data.keys()
         self.assertTrue('errorMessage' in keys and 'errorCode' in keys)
 
     @unittest.skipUnless(os.environ.get('AP_API_KEY', None), API_MESSAGE)
     def test_nonexistent_date(self):
-        nonexistent_date_response = self.api_request('/1965-01-01')
+        sleep(5)
+        nonexistent_date_response = self.api_request('/elections/1965-01-01')
         data = nonexistent_date_response.json()
         self.assertEqual(len(data['races']), 0)
 
     @unittest.skipUnless(os.environ.get('AP_API_KEY', None), API_MESSAGE)
     def test_nonexistent_param(self):
-        nonexistent_param_response = self.api_request('/', foo='bar')
+        sleep(5)
+        nonexistent_param_response = self.api_request('/elections/', foo='bar')
         self.assertEqual(nonexistent_param_response.status_code, 400)

--- a/tests/test_delegate_reports.py
+++ b/tests/test_delegate_reports.py
@@ -1,4 +1,9 @@
+import os
+import unittest
 import tests
+
+from . import API_MESSAGE
+
 try:
     set
 except NameError:
@@ -57,3 +62,14 @@ class TestDelegateReports(tests.DelegateReportTestCase):
             len(number_of_national_results),
             len(number_of_state_us_results)
         )
+
+    @unittest.skipUnless(os.environ.get('AP_API_KEY', None), API_MESSAGE)
+    def test_delegate_report_id_cache(self):
+        from elex.api.delegates import cache, _get_reports
+        _get_reports()
+        self.assertEqual(cache.stats()[0], 1)
+
+    def test_delegate_report_id_cache_clear(self):
+        from elex.api.delegates import cache, clear_delegate_cache
+        clear_delegate_cache()
+        self.assertEqual(cache.stats()[0], 0)


### PR DESCRIPTION
This is one possible solution to #234 . It uses a library called percache to cache the output of the reports call and adds `elex clear-delegate-cache` command to the cli that wipes out the delegate cache.

I think an alternative would be to use python requests-cache ... I'm not convinced this is the best way, but it is mostly functional.