### PR TITLE
add --with-timestamp flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ install:
 # command to run tests
 script:
   - pyflakes elex
-  - pep8 elex
+  - pep8 --max-line-length=90 elex
   - pyflakes tests
-  - pep8 tests
+  - pep8 --max-line-length=90 tests
   - python -m nose2.__main__ -v
 sudo: false

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -4,62 +4,63 @@ Command line interface
 
 ::
 
-  commands:
+commands:
 
-    ballot-measures
-      Get ballot positions (also known as ballot issues)
+  ballot-measures
+    Get ballot measures
 
-    candidate-reporting-units
-      Get candidate reporting units (without results)
+  candidate-reporting-units
+    Get candidate reporting units (without results)
 
-    candidates
-      Get candidates
+  candidates
+    Get candidates
 
-    delegates
-      Get all delegate reports
+  delegates
+    Get all delegate reports
 
-    elections
-      Get list of available elections
+  elections
+    Get list of available elections
 
-    next-election
-      Get the next election (if date is specified, will be relative to that date, otherwise will use today's date)
+  next-election
+    Get the next election (if date is specified, will be relative to that date, otherwise will use today's date)
 
-    races
-      Get races
+  races
+    Get races
 
-    reporting-units
-      Get reporting units
+  reporting-units
+    Get reporting units
 
-    results
-      Get results
+  results
+    Get results
 
-  positional arguments:
-    date                  Election date (e.g. "2015-11-03"; most common date
-                          formats accepted).
+positional arguments:
+  date                  Election date (e.g. "2015-11-03"; most common date
+                        formats accepted).
 
-  optional arguments:
-    -h, --help            show this help message and exit
-    --debug               toggle debug output
-    --quiet               suppress all output
-    -o {json,csv}         output format (default: csv)
-    -t, --test            Use testing API calls
-    -n, --not-live        Do not use live data API calls
-    -d DATA_FILE, --data-file DATA_FILE
-                          Specify data file instead of making HTTP request when
-                          using election commands like `elex results` and `elex
-                          races`.
-    --delegate-sum-file DELEGATE_SUM_FILE
-                          Specify delegate sum report file instead of making
-                          HTTP request when using `elex delegates`
-    --delegate-super-file DELEGATE_SUPER_FILE
-                          Specify delegate super report file instead of making
-                          HTTP request when using `elex delegates`
-    --local-only          Limit results to local-level results only, ignoring
-                          national races like President, House/Senate and
-                          Governor
-    --format-json         Pretty print JSON when using `-o json`.
-    --results-level       Specify reporting level when using `elex results`, 
-                          such as `district` or `state`
-    --set-zero-counts     Override results with zeros; omits the winner
-                          indicator.
-    -v, --version         Show program's version number and exit
+optional arguments:
+  -h, --help            show this help message and exit
+  --debug               toggle debug output
+  --quiet               suppress all output
+  -o {json,csv}         output format (default: csv)
+  -t, --test            Use testing API calls
+  -n, --not-live        Do not use live data API calls
+  -d DATA_FILE, --data-file DATA_FILE
+                        Specify data file instead of making HTTP request when
+                        using election commands like `elex results` and `elex
+                        races`.
+  --delegate-sum-file DELEGATE_SUM_FILE
+                        Specify delegate sum report file instead of making
+                        HTTP request when using `elex delegates`
+  --delegate-super-file DELEGATE_SUPER_FILE
+                        Specify delegate super report file instead of making
+                        HTTP request when using `elex delegates`
+  --format-json         Pretty print JSON when using `-o json`.
+  -v, --version         show program's version number and exit
+  --results-level RESULTS_LEVEL
+                        Specify reporting level for results
+  --set-zero-counts     Override results with zeros; omits the winner
+                        indicator.Sets the vote, delegate, and reporting
+                        precinct counts to zero.
+  --local-only          Limit results to local-level results only.
+  --with-timestamp      Append a timestamp column with current system time to
+                        data output.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -62,5 +62,7 @@ optional arguments:
                         indicator.Sets the vote, delegate, and reporting
                         precinct counts to zero.
   --local-only          Limit results to local-level results only.
-  --with-timestamp      Append a timestamp column with current system time to
-                        data output.
+  --with-timestamp      Append a `timestamp` column to each row of data output
+                        with current system timestamp.
+  --batch-name BATCH_NAME
+                        Specify a value for a `batchid` column that to append

--- a/elex/cli/app.py
+++ b/elex/cli/app.py
@@ -73,8 +73,8 @@ Sets the vote, delegate, and reporting precinct counts to zero.',
                 default=None
             )),
             (['--with-timestamp'], dict(
-                action='store_true',
-                help='Add timestamp column corresponding to runtime.',
+                action='store_false',
+                help='Append a timestamp column with current system time to data output.',
                 default=False
             )),
         ]

--- a/elex/cli/app.py
+++ b/elex/cli/app.py
@@ -74,7 +74,8 @@ Sets the vote, delegate, and reporting precinct counts to zero.',
             )),
             (['--with-timestamp'], dict(
                 action='store_false',
-                help='Append a timestamp column with current system time to data output.',
+                help='Append a timestamp column with current system time to data \
+output.',
                 default=False
             )),
         ]

--- a/elex/cli/app.py
+++ b/elex/cli/app.py
@@ -73,7 +73,7 @@ Sets the vote, delegate, and reporting precinct counts to zero.',
                 default=None
             )),
             (['--with-timestamp'], dict(
-                action='store_false',
+                action='store_true',
                 help='Append a timestamp column with current system time to data \
 output.',
                 default=False

--- a/elex/cli/app.py
+++ b/elex/cli/app.py
@@ -74,9 +74,12 @@ Sets the vote, delegate, and reporting precinct counts to zero.',
             )),
             (['--with-timestamp'], dict(
                 action='store_true',
-                help='Append a timestamp column with current system time to data \
-output.',
-                default=False
+                help='Append a `timestamp` column to each row of data output with current\
+                      system timestamp.',
+            )),
+            (['--batch-name'], dict(
+                action='store',
+                help='Specify a value for a `batchid` column that to append to each row.',
             )),
         ]
 

--- a/elex/cli/app.py
+++ b/elex/cli/app.py
@@ -72,6 +72,11 @@ Sets the vote, delegate, and reporting precinct counts to zero.',
                 help='Limit results to local-level results only.',
                 default=None
             )),
+            (['--with-timestamp'], dict(
+                action='store_true',
+                help='Add timestamp column corresponding to runtime.',
+                default=False
+            )),
         ]
 
     @expose(hide=True)

--- a/elex/cli/decorators.py
+++ b/elex/cli/decorators.py
@@ -18,10 +18,7 @@ def require_date_argument(fn):
                 )
                 return fn(self)
             except ValueError:
-                puts(
-                    colored.yellow('Whoa there, friend! There was an error:\n')
-                )
-                text = '{0} could not be recognized as a date.\n'
+                text = 'ERROR: {0} could not be recognized as a date.\n'
                 puts(text.format(colored.green(self.app.pargs.date[0])))
 
                 # Should exit status 1 so we can script against it.
@@ -50,8 +47,7 @@ def require_ap_api_key(fn):
             self.app.pargs.delegate_sum_file and
             self.app.pargs.delegate_super_file
         ) and not os.environ.get("AP_API_KEY", None):
-            puts(colored.yellow('Whoa there, friend! There was an error:\n'))
-            text = 'You have not exported {0} as an environment variable.\n'
+            text = 'ERROR: You have not exported {0} as an environment variable.\n'
             puts(text.format(colored.green("AP_API_KEY")))
 
             # Should exit status 1 so we can script against it.

--- a/elex/cli/decorators.py
+++ b/elex/cli/decorators.py
@@ -47,7 +47,8 @@ def require_ap_api_key(fn):
             self.app.pargs.delegate_sum_file and
             self.app.pargs.delegate_super_file
         ) and not os.environ.get("AP_API_KEY", None):
-            text = 'ERROR: You have not exported {0} as an environment variable.\n'
+            text = 'ERROR: You have not exported {0} as an environment \
+variable.\n'
             puts(text.format(colored.green("AP_API_KEY")))
 
             # Should exit status 1 so we can script against it.

--- a/elex/cli/ext_csv.py
+++ b/elex/cli/ext_csv.py
@@ -1,5 +1,6 @@
 import csv
 import sys
+import time
 from cement.core import handler, output
 
 
@@ -18,14 +19,19 @@ class CSVOutputHandler(output.CementOutputHandler):
         if len(data) == 0:
             return
 
+        now = time.time()
+
         try:
             # Properly terminate lines for Windows and Excel.
             # See: https://github.com/newsdev/elex/issues/232
             writer = csv.writer(sys.stdout, lineterminator='\n')
-            for i, row in enumerate(data):
+            for i, obj in enumerate(data):
+                row = obj.serialize()
+                if self.app.pargs.with_timestamp:
+                    row['timestamp'] = str(int(now))
                 if i == 0:
-                    writer.writerow(row.serialize().keys())
-                writer.writerow(row.serialize().values())
+                    writer.writerow(row.keys())
+                writer.writerow(row.values())
         except IOError:
             # Handle pipes that could close before output is done.
             # See: http://stackoverflow.com/questions/15793886/

--- a/elex/cli/ext_csv.py
+++ b/elex/cli/ext_csv.py
@@ -19,7 +19,8 @@ class CSVOutputHandler(output.CementOutputHandler):
         if len(data) == 0:
             return
 
-        now = time.time()
+        if self.app.pargs.with_timestamp:
+            now = time.time()
 
         try:
             # Properly terminate lines for Windows and Excel.
@@ -29,6 +30,8 @@ class CSVOutputHandler(output.CementOutputHandler):
                 row = obj.serialize()
                 if self.app.pargs.with_timestamp:
                     row['timestamp'] = str(int(now))
+                if self.app.pargs.batch_name:
+                    row['batchname'] = self.app.pargs.batch_name
                 if i == 0:
                     writer.writerow(row.keys())
                 writer.writerow(row.values())

--- a/elex/cli/ext_json.py
+++ b/elex/cli/ext_json.py
@@ -1,5 +1,6 @@
 import json
 import sys
+import time
 from bson import json_util
 from cement.core import handler, output
 
@@ -25,7 +26,16 @@ class ElexJSONOutputHandler(output.CementOutputHandler):
                 kwargs['sort_keys'] = True
                 kwargs['indent'] = 4
 
-            json_data = [row.serialize() for row in data]
+            if self.app.pargs.with_timestamp:
+                now = time.time()
+                json_data = []
+                for obj in data:
+                    row = obj.serialize()
+                    row['timestamp'] = str(int(now))
+                    json_data.append(row)
+            else:
+                json_data = [row.serialize() for row in data]
+
             json.dump(
                 json_data,
                 sys.stdout,

--- a/elex/cli/ext_json.py
+++ b/elex/cli/ext_json.py
@@ -31,7 +31,7 @@ class ElexJSONOutputHandler(output.CementOutputHandler):
                 json_data = []
                 for obj in data:
                     row = obj.serialize()
-                    row['timestamp'] = str(int(now))
+                    row['timestamp'] = int(now)
                     json_data.append(row)
             else:
                 json_data = [row.serialize() for row in data]

--- a/elex/cli/ext_json.py
+++ b/elex/cli/ext_json.py
@@ -28,13 +28,15 @@ class ElexJSONOutputHandler(output.CementOutputHandler):
 
             if self.app.pargs.with_timestamp:
                 now = time.time()
-                json_data = []
-                for obj in data:
-                    row = obj.serialize()
-                    row['timestamp'] = int(now)
-                    json_data.append(row)
-            else:
-                json_data = [row.serialize() for row in data]
+
+            json_data = []
+            for obj in data:
+                row = obj.serialize()
+                if self.app.pargs.with_timestamp:
+                    row['timestamp'] = str(int(now))
+                if self.app.pargs.batch_name:
+                    row['batchname'] = self.app.pargs.batch_name
+                json_data.append(row)
 
             json.dump(
                 json_data,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -105,14 +105,12 @@ class ElexCLICSVTestMeta(type):
             timestamp_test_name = 'test_csv_{0}_timestamp'.format(
                 command.replace('-', '_')
             )
-            dict[timestamp_test_name] = gen_timestamp_test(command,
-                                                           with_timestamp=True)
+            dict[timestamp_test_name] = gen_timestamp_test(command)
 
             timestamp_data_test_name = 'test_csv_{0}_timestamp_data'.format(
                 command.replace('-', '_')
             )
-            dict[timestamp_data_test_name] = gen_timestamp_data_test(command,
-                                                                     with_timestamp=True)
+            dict[timestamp_data_test_name] = gen_timestamp_data_test(command)
 
         return type.__new__(mcs, name, bases, dict)
 
@@ -261,7 +259,7 @@ class ElexCLICSVTestCase(
         argv = argv + ['--results-level', resultslevel]
 
         if with_timestamp:
-            argv.append('--with-timestamp')
+            argv = argv + ['--with-timestamp']
 
         app = ElexApp(argv=argv)
 
@@ -508,7 +506,7 @@ class ElexCLIJSONTestCase(
         argv = argv + ['--results-level', resultslevel]
 
         if with_timestamp:
-            argv.append('--with-timestamp')
+            argv = argv + ['--with-timestamp']
 
         app = ElexApp(argv=argv)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -82,7 +82,10 @@ class ElexCLICSVTestMeta(type):
                 cli_fields, cli_data = self._test_command(command=command,
                                                           with_timestamp=True)
                 for row in cli_data:
-                    self.assertTrue(row['timestamp'].isnumeric())
+                    try:
+                        self.assertTrue(unicode(row['timestamp']).isnumeric())
+                    except NameError:
+                        self.assertTrue(str(row['timestamp']).isnumeric())
 
             return test
 
@@ -330,7 +333,10 @@ class ElexCLIJSONTestMeta(type):
                 cli_fields, cli_data = self._test_command(command=command,
                                                           with_timestamp=True)
                 for row in cli_data:
-                    self.assertTrue(isinstance(row['timestamp'], int))
+                    try:
+                        self.assertTrue(unicode(row['timestamp']).isnumeric())
+                    except NameError:
+                        self.assertTrue(str(row['timestamp']).isnumeric())
 
             return test
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -105,12 +105,14 @@ class ElexCLICSVTestMeta(type):
             timestamp_test_name = 'test_csv_{0}_timestamp'.format(
                 command.replace('-', '_')
             )
-            dict[timestamp_test_name] = gen_timestamp_test(command)
+            dict[timestamp_test_name] = gen_timestamp_test(command,
+                                                           with_timestamp=True)
 
             timestamp_data_test_name = 'test_csv_{0}_timestamp_data'.format(
                 command.replace('-', '_')
             )
-            dict[timestamp_data_test_name] = gen_timestamp_data_test(command)
+            dict[timestamp_data_test_name] = gen_timestamp_data_test(command,
+                                                                     with_timestamp=True)
 
         return type.__new__(mcs, name, bases, dict)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -63,19 +63,36 @@ class ElexCLICSVTestMeta(type):
                         self.assertEqual(row[k], str(v))
             return test
 
+        def gen_timestamp_test(command):
+            """
+            Generate test to ensure timestamp field is set
+            """
+            def test(self):
+                cli_fields, cli_data = self._test_command(command=command, with_timestamp=True)
+                self.assertEqual(cli_fields[-1], 'timestamp')
+
+            return test
+
         for command in TEST_COMMANDS:
             fields_test_name = 'test_csv_{0}_fields'.format(
                 command.replace('-', '_')
             )
             dict[fields_test_name] = gen_fields_test(command)
+
             length_test_name = 'test_csv_{0}_length'.format(
                 command.replace('-', '_')
             )
             dict[length_test_name] = gen_length_test(command)
+
             data_test_name = 'test_csv_{0}_data'.format(
                 command.replace('-', '_')
             )
             dict[data_test_name] = gen_data_test(command)
+
+            timestamp_data_test_name = 'test_csv_{0}_data_timestamp'.format(
+                command.replace('-', '_')
+            )
+            dict[timestamp_data_test_name] = gen_timestamp_test(command)
 
         return type.__new__(mcs, name, bases, dict)
 
@@ -204,7 +221,8 @@ class ElexCLICSVTestCase(
         delsum_datafile=DELSUM_DATA_FILE,
         delsuper_datafile=DELSUPER_DATA_FILE,
         electiondate=DATA_ELECTION_DATE,
-        resultslevel=None
+        resultslevel=None,
+        with_timestamp=False
     ):
         """
         Execute an `elex` sub-command; returns fieldnames and rows
@@ -221,6 +239,9 @@ class ElexCLICSVTestCase(
         argv = argv + ['--delegate-sum-file', delsum_datafile]
         argv = argv + ['--delegate-super-file', delsuper_datafile]
         argv = argv + ['--results-level', resultslevel]
+
+        if with_timestamp:
+            argv.append('--with-timestamp')
 
         app = ElexApp(argv=argv)
 
@@ -272,19 +293,36 @@ class ElexCLIJSONTestMeta(type):
                         self.assertEqual(row[k], v)
             return test
 
+        def gen_timestamp_test(command):
+            """
+            Generate test to ensure timestamp field is set
+            """
+            def test(self):
+                cli_fields, cli_data = self._test_command(command=command, with_timestamp=True)
+                self.assertEqual(cli_fields[-1], 'timestamp')
+
+            return test
+
         for command in TEST_COMMANDS:
             fields_test_name = 'test_json_{0}_fields'.format(
                 command.replace('-', '_')
             )
             dict[fields_test_name] = gen_fields_test(command)
+
             length_test_name = 'test_json_{0}_length'.format(
                 command.replace('-', '_')
             )
             dict[length_test_name] = gen_length_test(command)
+
             data_test_name = 'test_json_{0}_data'.format(
                 command.replace('-', '_')
             )
             dict[data_test_name] = gen_data_test(command)
+
+            timestamp_data_test_name = 'test_json_{0}_data_timestamp'.format(
+                command.replace('-', '_')
+            )
+            dict[timestamp_data_test_name] = gen_timestamp_test(command)
 
         return type.__new__(mcs, name, bases, dict)
 
@@ -413,7 +451,8 @@ class ElexCLIJSONTestCase(
         delsum_datafile=DELSUM_DATA_FILE,
         delsuper_datafile=DELSUPER_DATA_FILE,
         electiondate=DATA_ELECTION_DATE,
-        resultslevel=None
+        resultslevel=None,
+        with_timestamp=False
     ):
         """
         Execute an `elex` sub-command; returns fieldnames and rows
@@ -429,6 +468,9 @@ class ElexCLIJSONTestCase(
         argv = argv + ['--delegate-sum-file', delsum_datafile]
         argv = argv + ['--delegate-super-file', delsuper_datafile]
         argv = argv + ['--results-level', resultslevel]
+
+        if with_timestamp:
+            argv.append('--with-timestamp')
 
         app = ElexApp(argv=argv)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -68,7 +68,8 @@ class ElexCLICSVTestMeta(type):
             Generate test to ensure timestamp field is set
             """
             def test(self):
-                cli_fields, cli_data = self._test_command(command=command, with_timestamp=True)
+                cli_fields, cli_data = self._test_command(command=command,
+                                                          with_timestamp=True)
                 self.assertEqual(cli_fields[-1], 'timestamp')
 
             return test
@@ -78,7 +79,8 @@ class ElexCLICSVTestMeta(type):
             Generate test to ensure timestamp field is set
             """
             def test(self):
-                cli_fields, cli_data = self._test_command(command=command, with_timestamp=True)
+                cli_fields, cli_data = self._test_command(command=command,
+                                                          with_timestamp=True)
                 for row in cli_data:
                     self.assertTrue(row['timestamp'].isnumeric())
 
@@ -314,7 +316,8 @@ class ElexCLIJSONTestMeta(type):
             Generate test to ensure timestamp field is set
             """
             def test(self):
-                cli_fields, cli_data = self._test_command(command=command, with_timestamp=True)
+                cli_fields, cli_data = self._test_command(command=command,
+                                                          with_timestamp=True)
                 self.assertEqual(cli_fields[-1], 'timestamp')
 
             return test
@@ -324,7 +327,8 @@ class ElexCLIJSONTestMeta(type):
             Generate test to ensure timestamp data is an integer
             """
             def test(self):
-                cli_fields, cli_data = self._test_command(command=command, with_timestamp=True)
+                cli_fields, cli_data = self._test_command(command=command,
+                                                          with_timestamp=True)
                 for row in cli_data:
                     self.assertTrue(isinstance(row['timestamp'], int))
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,6 +89,18 @@ class ElexCLICSVTestMeta(type):
 
             return test
 
+        def gen_batch_name_data_test(command):
+            """
+            Generate test to ensure timestamp field is set
+            """
+            def test(self):
+                cli_fields, cli_data = self._test_command(command=command,
+                                                          batch_name='batch-01')
+                for row in cli_data:
+                    self.assertEqual(row['batchname'], 'batch-01')
+
+            return test
+
         for command in TEST_COMMANDS:
             fields_test_name = 'test_csv_{0}_fields'.format(
                 command.replace('-', '_')
@@ -114,6 +126,11 @@ class ElexCLICSVTestMeta(type):
                 command.replace('-', '_')
             )
             dict[timestamp_data_test_name] = gen_timestamp_data_test(command)
+
+            batch_name_data_test_name = 'test_csv_{0}_batch_name_data'.format(
+                command.replace('-', '_')
+            )
+            dict[batch_name_data_test_name] = gen_batch_name_data_test(command)
 
         return type.__new__(mcs, name, bases, dict)
 
@@ -243,7 +260,8 @@ class ElexCLICSVTestCase(
         delsuper_datafile=DELSUPER_DATA_FILE,
         electiondate=DATA_ELECTION_DATE,
         resultslevel=None,
-        with_timestamp=False
+        with_timestamp=False,
+        batch_name=False
     ):
         """
         Execute an `elex` sub-command; returns fieldnames and rows
@@ -263,6 +281,9 @@ class ElexCLICSVTestCase(
 
         if with_timestamp:
             argv = argv + ['--with-timestamp']
+
+        if batch_name:
+            argv = argv + ['--batch-name', batch_name]
 
         app = ElexApp(argv=argv)
 
@@ -340,6 +361,18 @@ class ElexCLIJSONTestMeta(type):
 
             return test
 
+        def gen_batch_name_data_test(command):
+            """
+            Generate test to ensure timestamp field is set
+            """
+            def test(self):
+                cli_fields, cli_data = self._test_command(command=command,
+                                                          batch_name='batch-01')
+                for row in cli_data:
+                    self.assertEqual(row['batchname'], 'batch-01')
+
+            return test
+
         for command in TEST_COMMANDS:
             fields_test_name = 'test_json_{0}_fields'.format(
                 command.replace('-', '_')
@@ -365,6 +398,11 @@ class ElexCLIJSONTestMeta(type):
                 command.replace('-', '_')
             )
             dict[timestamp_data_test_name] = gen_timestamp_data_test(command)
+
+            batch_name_data_test_name = 'test_csv_{0}_batch_name_data'.format(
+                command.replace('-', '_')
+            )
+            dict[batch_name_data_test_name] = gen_batch_name_data_test(command)
 
         return type.__new__(mcs, name, bases, dict)
 
@@ -494,7 +532,8 @@ class ElexCLIJSONTestCase(
         delsuper_datafile=DELSUPER_DATA_FILE,
         electiondate=DATA_ELECTION_DATE,
         resultslevel=None,
-        with_timestamp=False
+        with_timestamp=False,
+        batch_name=False
     ):
         """
         Execute an `elex` sub-command; returns fieldnames and rows
@@ -513,6 +552,9 @@ class ElexCLIJSONTestCase(
 
         if with_timestamp:
             argv = argv + ['--with-timestamp']
+
+        if batch_name:
+            argv = argv + ['--batch-name', batch_name]
 
         app = ElexApp(argv=argv)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -73,6 +73,17 @@ class ElexCLICSVTestMeta(type):
 
             return test
 
+        def gen_timestamp_data_test(command):
+            """
+            Generate test to ensure timestamp field is set
+            """
+            def test(self):
+                cli_fields, cli_data = self._test_command(command=command, with_timestamp=True)
+                for row in cli_data:
+                    self.assertTrue(row['timestamp'].isnumeric())
+
+            return test
+
         for command in TEST_COMMANDS:
             fields_test_name = 'test_csv_{0}_fields'.format(
                 command.replace('-', '_')
@@ -89,10 +100,15 @@ class ElexCLICSVTestMeta(type):
             )
             dict[data_test_name] = gen_data_test(command)
 
-            timestamp_data_test_name = 'test_csv_{0}_data_timestamp'.format(
+            timestamp_test_name = 'test_csv_{0}_timestamp'.format(
                 command.replace('-', '_')
             )
-            dict[timestamp_data_test_name] = gen_timestamp_test(command)
+            dict[timestamp_test_name] = gen_timestamp_test(command)
+
+            timestamp_data_test_name = 'test_csv_{0}_timestamp_data'.format(
+                command.replace('-', '_')
+            )
+            dict[timestamp_data_test_name] = gen_timestamp_data_test(command)
 
         return type.__new__(mcs, name, bases, dict)
 
@@ -303,6 +319,17 @@ class ElexCLIJSONTestMeta(type):
 
             return test
 
+        def gen_timestamp_data_test(command):
+            """
+            Generate test to ensure timestamp data is an integer
+            """
+            def test(self):
+                cli_fields, cli_data = self._test_command(command=command, with_timestamp=True)
+                for row in cli_data:
+                    self.assertTrue(isinstance(row['timestamp'], int))
+
+            return test
+
         for command in TEST_COMMANDS:
             fields_test_name = 'test_json_{0}_fields'.format(
                 command.replace('-', '_')
@@ -323,6 +350,11 @@ class ElexCLIJSONTestMeta(type):
                 command.replace('-', '_')
             )
             dict[timestamp_data_test_name] = gen_timestamp_test(command)
+
+            timestamp_data_test_name = 'test_json_{0}_timestamp_data'.format(
+                command.replace('-', '_')
+            )
+            dict[timestamp_data_test_name] = gen_timestamp_data_test(command)
 
         return type.__new__(mcs, name, bases, dict)
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@
 envlist = py27, py35, pypy
 
 [testenv]
+deps = nose2
 commands = nose2 tests
 
 [pep8]


### PR DESCRIPTION
closes #212 

@ghing was it you who I talked with about doing this? Looking for some input before I submit. (Cc @jeremyjbowers)

Right now, the flag sets the timestamp to the run time when the command starts printing data. It *could* take an optional argument that would let you pass in a custom timestamp param so that you could do a script like:

```bash
NOW=`date +%s`
elex races 03-26-16 --with-timestamp $NOW
elex candidates 03-26-16 --with-timestamp $NOW
elex results 03-26-16 --with-timestamp $NOW
```