### PR TITLE
Change API_KEY environment variable to AP_API_KEY

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -8,7 +8,7 @@ The following environment variables may be set:
 
     export API_VERSION='v2'
     export BASE_URL='http://api.ap.org/v2'
-    export API_KEY='<<YOURAPIKEY>>'
+    export AP_API_KEY='<<YOURAPIKEY>>'
     export ELEX_DELEGATE_REPORT_ID_CACHE_FILE='/tmp/elex-cache'
     export ELEX_RECORDING='flat'
     export ELEX_RECORDING_DIR='/tmp/elex-recording'


### PR DESCRIPTION
In the installation section of the docs it says to run `export AP_API_KEY=<MY_AP_API_KEY>` if you run `export API_KEY=<MY_AP_API_KEY>` elex will error.