### PR TITLE
remove report caching

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,11 @@
+2.0.1 - 2.0.4 - April 26, 2016
+------------------------------
+
+* Fixes for AP API v2.1.
+* Fix for missing Rhode Island mail-in ballot (#263).
+* Fix for township to county rollups in New England (#264).
+* Delegate report cache has been removed; the feature could have negative consequences and will be better addressed by a full caching system.
+
 2.0.0 - April 14, 2016
 ----------------------
 

--- a/elex/__init__.py
+++ b/elex/__init__.py
@@ -1,11 +1,8 @@
 import os
 import pkg_resources
-import tempfile
 
 
 __version__ = pkg_resources.get_distribution('elex').version
 API_VERSION = os.environ.get('AP_API_VERSION', 'v2')
 BASE_URL = os.environ.get('AP_API_BASE_URL', 'http://api.ap.org/{0}'.format(API_VERSION))
 API_KEY = os.environ.get('AP_API_KEY', None)
-DEFAULT_TEMPDIR = os.path.join(tempfile.gettempdir(), 'elex-cache')
-DELEGATE_REPORT_ID_CACHE_FILE = os.environ.get('ELEX_DELEGATE_REPORT_ID_CACHE_FILE', DEFAULT_TEMPDIR)

--- a/elex/api/delegates.py
+++ b/elex/api/delegates.py
@@ -4,36 +4,20 @@ This module contains the primary :class:`DelegateLoad` class for handling a
 single load of AP delegate counts and methods necessary to obtain them.
 """
 import json
-import percache
 
-from elex import DELEGATE_REPORT_ID_CACHE_FILE
 from elex.api import utils
 from collections import OrderedDict
 
-CACHE_MAX_AGE = 30  # Max age of cache
 
-cache = percache.Cache(DELEGATE_REPORT_ID_CACHE_FILE, livesync=True)
-
-
-@cache
 def _get_reports(params={}):
     """
-    Use percache to dump a report response to disk
+    Get reports
     """
-    cache.clear(maxage=CACHE_MAX_AGE)
     resp = utils.api_request('/reports', **params)
     if resp.ok:
         return resp.json().get('reports')
     else:
-        cache.clear()
         return []
-
-
-def clear_delegate_cache():
-    """
-    Delete the delegate cache file
-    """
-    cache.clear()
 
 
 class CandidateDelegateReport(utils.UnicodeMixin):

--- a/elex/api/delegates.py
+++ b/elex/api/delegates.py
@@ -10,6 +10,8 @@ from elex import DELEGATE_REPORT_ID_CACHE_FILE
 from elex.api import utils
 from collections import OrderedDict
 
+CACHE_MAX_AGE = 30  # Max age of cache
+
 cache = percache.Cache(DELEGATE_REPORT_ID_CACHE_FILE, livesync=True)
 
 
@@ -18,6 +20,7 @@ def _get_reports(params={}):
     """
     Use percache to dump a report response to disk
     """
+    cache.clear(maxage=CACHE_MAX_AGE)
     resp = utils.api_request('/reports', **params)
     if resp.ok:
         return resp.json().get('reports')

--- a/elex/cli/app.py
+++ b/elex/cli/app.py
@@ -1,7 +1,5 @@
 from elex.api import Elections
 from elex.api import DelegateReport
-from elex.api.delegates import clear_delegate_cache
-from elex import DELEGATE_REPORT_ID_CACHE_FILE
 from elex import __version__ as VERSION
 from cement.core.foundation import CementApp
 from elex.cli.hooks import add_election_hook
@@ -387,11 +385,6 @@ Sets the vote, delegate, and reporting precinct counts to zero.',
             state,2472,0,Bush,MN,1239,1237,GOP,0,MN-1239,0,0,0
             state,2472,0,Bush,OR,1239,1237,GOP,0,OR-1239,0,0,0
 
-        Notes:
-
-        Your organization's report IDs are cached to cut down on API calls. If they change, you must
-        run `elex clear-delegate-cache` to reset.
-
         """
         self.app.log.info('Getting delegate reports')
         if (
@@ -403,9 +396,6 @@ Sets the vote, delegate, and reporting precinct counts to zero.',
                 delsum_datafile=self.app.pargs.delegate_sum_file
             )
         else:
-            self.app.log.debug(
-                'Elex delegate cache location: {0}'.format(DELEGATE_REPORT_ID_CACHE_FILE)
-            )
             report = DelegateReport()
 
         self.app.render(report.candidate_objects)

--- a/elex/cli/app.py
+++ b/elex/cli/app.py
@@ -446,28 +446,6 @@ relative to that date, otherwise will use today's date)")
 
         self.app.render(election)
 
-    @expose(help="Clear the delegate report ID cache.")
-    def clear_delegate_cache(self):
-        """
-        ``elex clear-delegates-cache``
-
-        Delete the cache of delegate report IDs.
-
-        Command:
-
-        .. code:: bash
-
-            elex clear-delegates-cache
-
-        Logging output:
-
-        .. code:: bash
-
-            2016-04-12 01:04:13,645 (INFO) elex (v2.0.0) : Deleting delegate report ID cache (/var/folders/z2/qlshs7cn51d_bctxsfd86qj80000gn/T/elex-cache)
-        """
-        self.app.log.info('Deleting delegate report ID cache ({0})'.format(DELEGATE_REPORT_ID_CACHE_FILE))
-        clear_delegate_cache()
-
 
 class ElexApp(CementApp):
     class Meta:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def read(filename):
 
 setup(
     name='elex',
-    version='2.0.3',
+    version='2.0.4',
     author='Jeremy Bowers, David Eads',
     author_email='jeremy.bowers@nytimes.com, deads@npr.org',
     url='https://github.com/newsdev/elex',

--- a/tests/test_delegate_reports.py
+++ b/tests/test_delegate_reports.py
@@ -2,6 +2,7 @@ import os
 import unittest
 import tests
 
+from time import sleep
 from . import API_MESSAGE
 
 try:
@@ -68,6 +69,15 @@ class TestDelegateReports(tests.DelegateReportTestCase):
         from elex.api.delegates import cache, _get_reports
         _get_reports()
         self.assertEqual(cache.stats()[0], 1)
+
+    @unittest.skipUnless(os.environ.get('AP_API_KEY', None), API_MESSAGE)
+    def test_delegate_report_id_cache_maxage(self):
+        from elex.api import delegates
+        delegates.CACHE_MAX_AGE = 5
+        delegates._get_reports()
+        sleep(delegates.CACHE_MAX_AGE + 1)
+        delegates.cache.clear(maxage=delegates.CACHE_MAX_AGE)
+        self.assertEqual(delegates.cache.stats()[0], 0)
 
     def test_delegate_report_id_cache_clear(self):
         from elex.api.delegates import cache, clear_delegate_cache

--- a/tests/test_delegate_reports.py
+++ b/tests/test_delegate_reports.py
@@ -1,9 +1,4 @@
-import os
-import unittest
 import tests
-
-from time import sleep
-from . import API_MESSAGE
 
 try:
     set

--- a/tests/test_delegate_reports.py
+++ b/tests/test_delegate_reports.py
@@ -63,23 +63,3 @@ class TestDelegateReports(tests.DelegateReportTestCase):
             len(number_of_national_results),
             len(number_of_state_us_results)
         )
-
-    @unittest.skipUnless(os.environ.get('AP_API_KEY', None), API_MESSAGE)
-    def test_delegate_report_id_cache(self):
-        from elex.api.delegates import cache, _get_reports
-        _get_reports()
-        self.assertEqual(cache.stats()[0], 1)
-
-    @unittest.skipUnless(os.environ.get('AP_API_KEY', None), API_MESSAGE)
-    def test_delegate_report_id_cache_maxage(self):
-        from elex.api import delegates
-        delegates.CACHE_MAX_AGE = 5
-        delegates._get_reports()
-        sleep(delegates.CACHE_MAX_AGE + 1)
-        delegates.cache.clear(maxage=delegates.CACHE_MAX_AGE)
-        self.assertEqual(delegates.cache.stats()[0], 0)
-
-    def test_delegate_report_id_cache_clear(self):
-        from elex.api.delegates import cache, clear_delegate_cache
-        clear_delegate_cache()
-        self.assertEqual(cache.stats()[0], 0)


### PR DESCRIPTION
Means you should call delegate reports no more frequently than every 30s with 2.0. 