### PR TITLE
add LICENSE to MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include requirements.txt
+include LICENSE


### PR DESCRIPTION
I'm planning a build of `elex` for [conda-forge](http://conda-forge.github.io). For our builds we like to include a hard-link to the actual license, but that means that the license must be indexed in the MANIFEST for distribution with the source. (plus, it's good policy.) This patch should include the license file in future source distributions.