### PR TITLE
Refactoring of the __str__ methods on API model classes so they are reflected when objects are printed

### DIFF
--- a/elex/api/models.py
+++ b/elex/api/models.py
@@ -784,7 +784,7 @@ class Race(APElection):
             ('uncontested', self.uncontested)
         ))
 
-    def __str__(self):
+    def __unicode__(self):
         return "%s %s" % (self.racetype, self.officename)
 
 

--- a/elex/api/models.py
+++ b/elex/api/models.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 import ujson as json
 import datetime
 from elex.api import maps
@@ -429,7 +430,7 @@ class CandidateReportingUnit(APElection):
             payload = "%s %s (%s)" % (self.first, self.last, self.party)
         if self.winner:
             payload += ' (w)'
-        return payload
+        return "{}".format(payload)
 
 
 class ReportingUnit(APElection):
@@ -879,7 +880,7 @@ class Election(APElection):
         self._response = None
 
     def __unicode__(self):
-        return self.electiondate
+        return "{}".format(self.electiondate)
 
     def set_id_field(self):
         """

--- a/elex/api/models.py
+++ b/elex/api/models.py
@@ -422,7 +422,7 @@ class CandidateReportingUnit(APElection):
             ('winner', self.winner),
         ))
 
-    def __str__(self):
+    def __unicode__(self):
         if self.is_ballot_measure:
             payload = "%s" % self.party
         else:
@@ -504,7 +504,7 @@ class ReportingUnit(APElection):
         self.set_candidate_votepct()
         self.set_id_field()
 
-    def __str__(self):
+    def __unicode__(self):
         template = "%s %s (%s %% reporting)"
         if self.reportingunitname:
             return template % (
@@ -878,7 +878,7 @@ class Election(APElection):
 
         self._response = None
 
-    def __str__(self):
+    def __unicode__(self):
         return self.electiondate
 
     def set_id_field(self):

--- a/elex/api/utils.py
+++ b/elex/api/utils.py
@@ -25,7 +25,7 @@ class UnicodeMixin(object):
         __str__ = lambda x: six.text_type(x).encode('utf-8')
 
     def __repr__(self):
-        return self.__str__()
+        return '<{}: {}>'.format(self.__class__.__name__, self.__str__())
 
 
 def write_recording(payload):

--- a/elex/api/utils.py
+++ b/elex/api/utils.py
@@ -24,6 +24,9 @@ class UnicodeMixin(object):
     else:
         __str__ = lambda x: six.text_type(x).encode('utf-8')
 
+    def __repr__(self):
+        return self.__str__()
+
 
 def write_recording(payload):
     """


### PR DESCRIPTION
Under the current regime when a list of model objects is printed, say by ``election.races``, the result does not include the string representation of each object. 

```python
>>> pprint(election.races)
[<elex.api.models.Race object at 0x7f8905389b90>,                                                                                                                             
 <elex.api.models.Race object at 0x7f8905389c50>,
 <elex.api.models.Race object at 0x7f8905389d10>,
 <elex.api.models.Race object at 0x7f8905389dd0>,
 <elex.api.models.Race object at 0x7f8905389e90>,
 <elex.api.models.Race object at 0x7f8905389f50>,
 <elex.api.models.Race object at 0x7f8905390050>,
 <elex.api.models.Race object at 0x7f8905390110>,
 <elex.api.models.Race object at 0x7f89053901d0>,
 <elex.api.models.Race object at 0x7f8905390290>,
 <elex.api.models.Race object at 0x7f8905390350>,
 <elex.api.models.Race object at 0x7f8905390410>,
 <elex.api.models.Race object at 0x7f89053904d0>,
 <elex.api.models.Race object at 0x7f8905390590>,
 <elex.api.models.Race object at 0x7f89053906d0>,
 <elex.api.models.Race object at 0x7f8905390810>,
 <elex.api.models.Race object at 0x7f8905390950>]
```

In an attempt to address this, I have added a ``__repr__`` method to the base ``UnicodeMixin`` class. In the process, it seemed to my eyes that the ``__str__`` methods currently in use did not connect with the ``__unicode__`` calls [made by the base class in Python 2 or 3](https://github.com/newsdev/elex/blob/master/elex/api/utils.py#L22-L25):

```python

class UnicodeMixin(object):
    """
    Python 2 + 3 compatibility for __unicode__
    """
    if sys.version_info > (3, 0):
        __str__ = lambda x: x.__unicode__()
    else:
        __str__ = lambda x: six.text_type(x).encode('utf-8')
```

After consulting the [documentation here](https://docs.python.org/3.3/howto/pyporting.html#str-unicode) it seemed to me that perhaps those model methods should be changed from ``__str__`` to ``__unicode__``.

The result is that when you run the same print statement as above you should now see:

```python
>>> pprint(election.races)
[<Race: None President>,
 <Race: None U.S. House>,
 <Race: None U.S. House>,
 <Race: None U.S. House>,
 <Race: None U.S. House>,
 <Race: None U.S. House>,
 <Race: None U.S. House>,
 <Race: None U.S. House>,
 <Race: None U.S. House>,
 <Race: None U.S. House>,
 <Race: None U.S. House>,
 <Race: None U.S. House>,
 <Race: None U.S. House>,
 <Race: None U.S. House>,
 <Race: None U.S. House>,
 <Race: None U.S. House>,
 <Race: None U.S. House>,
 <Race: None U.S. House>,
 <Race: None U.S. House>,
 <Race: None U.S. House>]
```

I haven't been in the repo here in a while, so please let me know if I've run myself off the cliff. 