### PR TITLE
Eliminate unneeded extra slash in path

### DIFF
--- a/elex/api/models.py
+++ b/elex/api/models.py
@@ -962,7 +962,7 @@ class Election(APElection):
                 self.electiondate = payload.get('electionDate')
                 return payload
         else:
-            payload = self.get('/%s' % self.electiondate, **params)
+            payload = self.get('%s' % self.electiondate, **params)
             return payload
 
     def get_race_objects(self, parsed_json):

--- a/elex/api/models.py
+++ b/elex/api/models.py
@@ -962,7 +962,7 @@ class Election(APElection):
                 self.electiondate = payload.get('electionDate')
                 return payload
         else:
-            payload = self.get('%s' % self.electiondate, **params)
+            payload = self.get(self.electiondate, **params)
             return payload
 
     def get_race_objects(self, parsed_json):


### PR DESCRIPTION
Apologies if this is incorrect, my Python-fu is weak.

I'm running ap-deja-vu and point Elex at it. When I do so, I get the following output from the server (IP masked):

```
x.x.x.x - - [26/Oct/2016 15:48:43] "GET /elections/2016/deja-vu/elections//2016-11-08?apiKey=jGX99E5kXpAzyre56LMLnB2G4BAWTTCG&format=json&level=ru&omitResults=False&setzerocounts=False&test=True HTTP/1.1" 404 -
```

If I remove the extra slash, it successfully connects. It looks like the change in this PR is needed because line 609 of models.py already prepends a slash:

``` python
self._response = utils.api_request('/elections/{0}'.format(path), **params)
```

Thanks!
