### PR TITLE
Fix Winning # being saved as Leading # in trend reports

### DIFF
--- a/elex/api/trends.py
+++ b/elex/api/trends.py
@@ -116,7 +116,7 @@ class BaseTrendReport(utils.UnicodeMixin):
                 party=party['title'],
                 office=self.raw_data['office'],
                 won=self._parse_trend('Won', party['trend']),
-                leading=self._parse_trend('Won', party['trend']),
+                leading=self._parse_trend('Leading', party['trend']),
                 holdovers=self._parse_trend('Holdovers', party['trend']),
                 winning_trend=self._parse_trend('Winning Trend', party['trend']),
                 current=self._parse_trend('Current', party['trend']),

--- a/tests/test_trend_reports.py
+++ b/tests/test_trend_reports.py
@@ -5,11 +5,30 @@ class TestDelegateReports(tests.TrendReportTestCase):
     """
     @TODO Not very sufficient tests
     """
-
     def test_us_governor_net_winners(self):
         trend = self.governor_trends.parties[0]
         self.assertEqual(trend.net_winners, '-2')
 
+    def test_us_governor_dem_won(self):
+        trend = self.governor_trends.parties[0]
+        self.assertEqual(trend.won, '6')
+
+    def test_us_governor_dem_leading(self):
+        trend = self.governor_trends.parties[0]
+        self.assertEqual(trend.leading, '0')
+
     def test_us_governor_gop_won(self):
         trend = self.governor_trends.parties[1]
         self.assertEqual(trend.won, '4')
+
+    def test_us_governor_gop_leading(self):
+        trend = self.governor_trends.parties[1]
+        self.assertEqual(trend.leading, '0')
+
+    def test_us_governor_other_won(self):
+        trend = self.governor_trends.parties[2]
+        self.assertEqual(trend.won, '0')
+
+    def test_us_governor_other_leading(self):
+        trend = self.governor_trends.parties[2]
+        self.assertEqual(trend.leading, '0')


### PR DESCRIPTION
Here's the current output from `elex senate-trends`:

```json
[
    {
        "current": "51",
        "holdovers": "30",
        "insufficient_vote": "0",
        "leading": "23",
        "net_leaders": "0",
        "net_winners": "+2",
        "office": "U.S. Senate",
        "party": "Dem",
        "winning_trend": "53",
        "won": "23"
    },
    {
        "current": "47",
        "holdovers": "37",
        "insufficient_vote": "0",
        "leading": "8",
        "net_leaders": "0",
        "net_winners": "-2",
        "office": "U.S. Senate",
        "party": "GOP",
        "winning_trend": "45",
        "won": "8"
    },
    {
        "current": "2",
        "holdovers": "0",
        "insufficient_vote": "0",
        "leading": "2",
        "net_leaders": "0",
        "net_winners": "0",
        "office": "U.S. Senate",
        "party": "Others",
        "winning_trend": "2",
        "won": "2"
    }
]
```

Note the duplicate values on `leading`/`won`. This PR fixes that duplication and parses the AP's `Leading` field to `leading` in the `elex` output.