### PR TITLE
Fix broken Poynter link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ News
 ====
 
 * `Introducing Elex, A Tool To Make Election Coverage Better For Everyone <https://source.opennews.org/en-US/articles/introducing-elex-tool-make-election-coverage-bette/>`_, Jeremy Bowers and David Eads, Source
-* `NPR and The New York Times teamed up to make election reporting faster <http://www.poynter.org/news/mediawire/388642/npr-and-the-new-york-times-teamed-up-to-make-election-reporting-faster/>`_, Benjamin Mullin, Poynter
+* `NPR and The New York Times teamed up to make election reporting faster <https://www.poynter.org/news/npr-and-new-york-times-teamed-make-election-reporting-faster>`_, Benjamin Mullin, Poynter
 
 Using the FTP system?
 =====================


### PR DESCRIPTION
## Changes

- Updates link in README.rst to Poynter coverage of Elex, because Poynter changed their permalink structure. The old link is available on the Wayback Machine: https://web.archive.org/web/*/http://www.poynter.org/news/mediawire/388642/npr-and-the-new-york-times-teamed-up-to-make-election-reporting-faster/