### PR TITLE
Support the 'electiondate' argument when pulling trend reports

### DIFF
--- a/elex/api/trends.py
+++ b/elex/api/trends.py
@@ -82,6 +82,10 @@ class BaseTrendReport(utils.UnicodeMixin):
             self.output_parties()
 
     def format_api_request_params(self):
+        """
+        Sets params for both fetches in a given trend-report download
+        (i.e., list of reports and detail page).
+        """
         params = {}
 
         if self.api_key is not None:
@@ -114,6 +118,7 @@ class BaseTrendReport(utils.UnicodeMixin):
     def get_ap_report(self, params={}):
         """
         Given a report number, returns a list of counts by party.
+
         Makes a request from the AP using requests. Formats that request
         with env vars.
         """
@@ -128,8 +133,13 @@ class BaseTrendReport(utils.UnicodeMixin):
 
     def get_report_id(self, reports):
         """
-        Takes a delSuper or delSum as the argument and returns
-        organization-specific report ID.
+        Narrows a list of all reports to just the type (U.S. House/U.S.
+        Senate/Governorships) specified in the subclass.
+
+        If an election date was specified, limits results to those on
+        that day. Otherwise, finds the overall most recent report.
+
+        Returns the versioned report ID where one exists.
         """
         matching_reports = [
             report for report in reports if report.get('title') in [

--- a/elex/api/trends.py
+++ b/elex/api/trends.py
@@ -56,15 +56,20 @@ class BaseTrendReport(utils.UnicodeMixin):
     office_code = None
     api_report_id = 'Trend / g / US'
 
-    def __init__(self, **kwargs):
+    def __init__(self, *args, **kwargs):
         if not self.office_code or not self.api_report_id:
             raise NotImplementedError
 
-        self.testresults = kwargs.get('testresults', False)
+        if len(args):
+            # Shim to support former method signature.
+            defaults['trendfile'] = args[0] if len(args) > 0 else None
+            defaults['testresults'] = args[1] if len(args) > 1 else False
+
+        self.testresults = kwargs.get('testresults', defaults['testresults'])
 
         self.electiondate = kwargs.get('electiondate', None)
         self.api_key = kwargs.get('api_key', None)
-        self.trendfile = kwargs.get('trend_file', None)
+        self.trendfile = kwargs.get('trend_file', defaults['trendfile'])
 
         self.load_raw_data()
 

--- a/elex/api/trends.py
+++ b/elex/api/trends.py
@@ -60,10 +60,11 @@ class BaseTrendReport(utils.UnicodeMixin):
         if not self.office_code or not self.api_report_id:
             raise NotImplementedError
 
-        if len(args):
-            # Shim to support former method signature.
-            defaults['trendfile'] = args[0] if len(args) > 0 else None
-            defaults['testresults'] = args[1] if len(args) > 1 else False
+        # Shim to support former method signature.
+        defaults = {
+            'trendfile': args[0] if len(args) > 0 else None,
+            'testresults': args[1] if len(args) > 1 else False,
+        }
 
         self.testresults = kwargs.get('testresults', defaults['testresults'])
 
@@ -100,12 +101,10 @@ class BaseTrendReport(utils.UnicodeMixin):
         if self.trendfile:
             self.raw_data = self.get_ap_file()
         else:
-            self.raw_data = self.get_ap_report(
-                params={
-                    'test': self.testresults,
-                    **self.format_api_request_params(),
-                }
-            )
+            report_params = self.format_api_request_params()
+            report_params['test'] = self.testresults
+
+            self.raw_data = self.get_ap_report(params=report_params)
 
     def get_ap_file(self):
         """

--- a/elex/cli/app.py
+++ b/elex/cli/app.py
@@ -420,7 +420,7 @@ Sets the vote, delegate, and reporting precinct counts to zero.',
 
         report = USGovernorTrendReport(**report_params)
 
-        self.app.render(report.parties)
+        self.app.render(report.parties if report.parties is not None else [])
 
     @expose(help="Get US House trend report")
     @require_ap_api_key
@@ -469,7 +469,7 @@ Sets the vote, delegate, and reporting precinct counts to zero.',
 
         report = USHouseTrendReport(**report_params)
 
-        self.app.render(report.parties)
+        self.app.render(report.parties if report.parties is not None else [])
 
     @expose(help="Get US Senate trend report")
     @require_ap_api_key
@@ -518,7 +518,7 @@ Sets the vote, delegate, and reporting precinct counts to zero.',
 
         report = USSenateTrendReport(**report_params)
 
-        self.app.render(report.parties)
+        self.app.render(report.parties if report.parties is not None else [])
 
     @expose(help="Get the next election (if date is specified, will be \
 relative to that date, otherwise will use today's date)")

--- a/elex/cli/app.py
+++ b/elex/cli/app.py
@@ -3,7 +3,7 @@ from cement.core.foundation import CementApp
 from cement.ext.ext_logging import LoggingLogHandler
 from elex.api import Elections, DelegateReport, USGovernorTrendReport, USHouseTrendReport, USSenateTrendReport
 from elex.cli.constants import BANNER, LOG_FORMAT
-from elex.cli.decorators import require_date_argument, require_ap_api_key
+from elex.cli.decorators import accept_date_argument, require_date_argument, require_ap_api_key
 from elex.cli.hooks import add_election_hook, cachecontrol_logging_hook
 from shutil import rmtree
 
@@ -375,6 +375,7 @@ Sets the vote, delegate, and reporting precinct counts to zero.',
 
     @expose(help="Get governor trend report")
     @require_ap_api_key
+    @accept_date_argument
     def governor_trends(self):
         """
         ``elex governor-trends``
@@ -395,11 +396,35 @@ Sets the vote, delegate, and reporting precinct counts to zero.',
             Dem,Governor,7,7,12,19,20,0,-1,0
         """
         self.app.log.info('Getting governor trend report')
-        report = USGovernorTrendReport(self.app.pargs.trend_file)
+
+        report_params = {
+            'testresults': self.app.pargs.test is True,
+        }
+
+        if self.app.election.electiondate is not None:
+            if self.app.pargs.test is True:
+                self.app.log.info(
+                    'Fetching test report for election {0}'.format(
+                        self.app.election.electiondate
+                    )
+                )
+            else:
+                self.app.log.info('Fetching report for election {0}'.format(
+                    self.app.election.electiondate
+                ))
+
+            report_params['electiondate'] = self.app.election.electiondate
+
+        if self.app.pargs.trend_file is not None:
+            report_params['trend_file'] = self.app.pargs.trend_file
+
+        report = USGovernorTrendReport(**report_params)
+
         self.app.render(report.parties)
 
     @expose(help="Get US House trend report")
     @require_ap_api_key
+    @accept_date_argument
     def house_trends(self):
         """
         ``elex house-trends``
@@ -420,11 +445,35 @@ Sets the vote, delegate, and reporting precinct counts to zero.',
             Dem,U.S. House,201,201,0,201,193,0,+8,0
         """
         self.app.log.info('Getting US House trend report')
-        report = USHouseTrendReport(self.app.pargs.trend_file)
+
+        report_params = {
+            'testresults': self.app.pargs.test is True,
+        }
+
+        if self.app.election.electiondate is not None:
+            if self.app.pargs.test is True:
+                self.app.log.info(
+                    'Fetching test report for election {0}'.format(
+                        self.app.election.electiondate
+                    )
+                )
+            else:
+                self.app.log.info('Fetching report for election {0}'.format(
+                    self.app.election.electiondate
+                ))
+
+            report_params['electiondate'] = self.app.election.electiondate
+
+        if self.app.pargs.trend_file is not None:
+            report_params['trend_file'] = self.app.pargs.trend_file
+
+        report = USHouseTrendReport(**report_params)
+
         self.app.render(report.parties)
 
     @expose(help="Get US Senate trend report")
     @require_ap_api_key
+    @accept_date_argument
     def senate_trends(self):
         """
         ``elex senate-trends``
@@ -445,7 +494,30 @@ Sets the vote, delegate, and reporting precinct counts to zero.',
             Dem,U.S. Senate,23,23,30,53,51,0,+2,0
         """
         self.app.log.info('Getting US Senate trend report')
-        report = USSenateTrendReport(self.app.pargs.trend_file)
+
+        report_params = {
+            'testresults': self.app.pargs.test is True,
+        }
+
+        if self.app.election.electiondate is not None:
+            if self.app.pargs.test is True:
+                self.app.log.info(
+                    'Fetching test report for election {0}'.format(
+                        self.app.election.electiondate
+                    )
+                )
+            else:
+                self.app.log.info('Fetching report for election {0}'.format(
+                    self.app.election.electiondate
+                ))
+
+            report_params['electiondate'] = self.app.election.electiondate
+
+        if self.app.pargs.trend_file is not None:
+            report_params['trend_file'] = self.app.pargs.trend_file
+
+        report = USSenateTrendReport(**report_params)
+
         self.app.render(report.parties)
 
     @expose(help="Get the next election (if date is specified, will be \

--- a/elex/cli/decorators.py
+++ b/elex/cli/decorators.py
@@ -31,7 +31,9 @@ def accept_date_argument(fn):
     """
     @wraps(fn)
     def decorated(self):
-        if len(self.app.pargs.date) and self.app.pargs.date[0]:
+        if self.app.pargs.data_file:
+            return fn(self)
+        elif len(self.app.pargs.date) and self.app.pargs.date[0]:
             returned_value = attach_election_date(self.app, fn, self)
             return returned_value
         return fn(self)

--- a/elex/cli/decorators.py
+++ b/elex/cli/decorators.py
@@ -6,9 +6,42 @@ from requests.exceptions import ConnectionError, HTTPError
 from xml.dom.minidom import parseString
 
 
+def attach_election_date(app, wrapped_fn, callback_context):
+    """
+    Attaches value of date argument to election model used in commands.
+
+    Common to both `accept_date_argument` and `require_date_argument`
+    decorators (i.e., this is called whether the date argument is
+    mandatory or optional).
+    """
+    try:
+        app.election.electiondate = parse_date(app.pargs.date[0])
+        return wrapped_fn(callback_context)
+    except ValueError:
+        text = '{0} could not be recognized as a date.'
+        app.log.error(text.format(app.pargs.date[0]))
+        app.close(1)
+
+    return wrapped_fn(callback_context)
+
+
+def accept_date_argument(fn):
+    """
+    Decorator that checks for optional date argument.
+    """
+    @wraps(fn)
+    def decorated(self):
+        if len(self.app.pargs.date) and self.app.pargs.date[0]:
+            returned_value = attach_election_date(self.app, fn, self)
+            return returned_value
+        return fn(self)
+
+    return decorated
+
+
 def require_date_argument(fn):
     """
-    Decorator that checks for date argument.
+    Decorator that checks for required date argument.
     """
     @wraps(fn)
     def decorated(self):
@@ -16,17 +49,7 @@ def require_date_argument(fn):
         if self.app.pargs.data_file:
             return fn(self)
         elif len(self.app.pargs.date) and self.app.pargs.date[0]:
-            try:
-                self.app.election.electiondate = parse_date(
-                    self.app.pargs.date[0]
-                )
-                return fn(self)
-            except ValueError:
-                text = '{0} could not be recognized as a date.'
-                self.app.log.error(text.format(self.app.pargs.date[0]))
-                self.app.close(1)
-
-            return fn(self)
+            return attach_election_date(self.app, fn, self)
         else:
             text = 'No election date (e.g. `elex {0} 2015-11-\
 03`) or data file (e.g. `elex {0} --data-file path/to/file.json`) specified.'


### PR DESCRIPTION
This branch adds a couple configuration options to `elex.api.trends.BaseTrendReport`, and also to the corresponding CLI tasks (`elex.cli.app.ElexBaseController.{governor|house|senate}_trends`).

Chief among these additions is support for an `electiondate` option in the `BaseTrendReport` constructor, which filters the returned list of reports by election-date value. That enables users to get balance-of-power reports for several past elections. (The other added option is `api_key` for explicit key settings -- since the AP has required organizations including ours to use separate keys for national and state-by-state data in the past.)

All arguments passed to the `BaseTrendReport` constructor now come in as `*args, **kwargs`, which adds future flexibility. Consequently, the parameters that were already supported (`trend_file` and `testresults`) retain their names and default values, but the logic by which they are set changes slightly.

The `{governor|house|senate}-trends` CLI commands have been modified to accept — but not require — a date value. In prior releases, a date value wouldn't raise an error, but _would_ be ignored. This date support has been added by creating a new CLI-command decorator that mimics the behavior of `elex.cli.decorators.require_date_argument`, but without erroring out if no date was set.

(These three CLI commands continue to support the optional `trend_file` and `test` arguments as in previous versions. Arguments that are common to all the CLI tasks [`batch_name`, `debug`, `format_json`, `suppress_output`, `output_handler_override` and `with_timestamp`] have all been tested and should still work properly as well.)

These changes have been tested* using `make test` in Python 2.7.8 and 3.6.5, as well as in the latest Homebrew-installed PyPy. However, I haven't written any additional tests or documentation for these — nor have I bumped any version numbers in `setup.py` or elsewhere (I wanted feedback on what's needed before I did so).

Please let me know how these changes look. I'd love to get them incorporated before the election, if it's possible.

* `make test` actually fails due to a few linting issues that pre-date my forking of the repo. I've resolved them in a branch on my own forked repo, and will submit a second PR with these minor changes when/if this current PR gets merged