### PR TITLE
Typo correction: Politian -> Politician

### DIFF
--- a/elex/api/models.py
+++ b/elex/api/models.py
@@ -255,7 +255,7 @@ class BallotMeasure(APElection):
         Generate and set unique id.
 
         Candidate IDs are not globally unique.
-        AP National Politian IDs (NPIDs or polid)
+        AP National Politician IDs (NPIDs or polid)
         are unique, but only national-level
         candidates have them; everyone else gets '0'.
         The unique key, then, is the NAME of the ID
@@ -361,7 +361,7 @@ class CandidateReportingUnit(APElection):
         Generate and set unique id.
 
         Candidate IDs are not globally unique.
-        AP National Politian IDs (NPIDs or polid)
+        AP National Politician IDs (NPIDs or polid)
         are unique, but only national-level
         candidates have them; everyone else gets '0'.
         The unique key, then, is the NAME of the ID


### PR DESCRIPTION
Sorry for the repeated PRs. Didn't realize this typo got copy/pasted throughout models.py until after the first PR.