### PR TITLE
Lock jinja2 version for docs generator

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+jinja2==3.0.3
 Sphinx==1.5.6
 sphinx-rtd-theme==0.1.9
 


### PR DESCRIPTION
The latest version of jinja2 is incompatible with the current docs
setup, so lock the version to make sure the docs can still be built.