### PR TITLE
Resultstype implemented

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build/
 *.spec
 nyt_*.py
 nyt_*.json
+.env

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,17 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+elex = {editable = true, path = "."}
+
+[dev-packages]
+sphinx = "==1.5.6"
+sphinx-rtd-theme = "==0.1.9"
+nose2 = "*"
+tox = "*"
+flake8 = "*"
+
+[requires]
+python_version = "3.10"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,642 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "e755569d311074058fdfd7fb9ef1c8ba0037fa07cbb455344ab0b5deb634c979"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.10"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "cachecontrol": {
+            "hashes": [
+                "sha256:2c75d6a8938cb1933c75c50184549ad42728a27e9f6b92fd677c3151aa72555b",
+                "sha256:a5b9fcc986b184db101aa280b42ecdcdfc524892596f606858e0b7a8b4d9e144"
+            ],
+            "markers": "python_full_version >= '3.6.0'",
+            "version": "==0.12.11"
+        },
+        "cement": {
+            "hashes": [
+                "sha256:d50c5980bf3e2456e515178ba097d16e36be0fbcab7811a60589d22f45b64f55"
+            ],
+            "version": "==2.10.2"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d",
+                "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"
+            ],
+            "markers": "python_full_version >= '3.6.0'",
+            "version": "==2022.6.15"
+        },
+        "charset-normalizer": {
+            "hashes": [
+                "sha256:5189b6f22b01957427f35b6a08d9a0bc45b46d3788ef5a92e978433c7a35f8a5",
+                "sha256:575e708016ff3a5e3681541cb9d79312c416835686d054a23accb873b254f413"
+            ],
+            "markers": "python_full_version >= '3.6.0'",
+            "version": "==2.1.0"
+        },
+        "elex": {
+            "editable": true,
+            "path": "."
+        },
+        "idna": {
+            "hashes": [
+                "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
+                "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==3.3"
+        },
+        "lockfile": {
+            "hashes": [
+                "sha256:6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799",
+                "sha256:6c3cb24f344923d30b2785d5ad75182c8ea7ac1b6171b08657258ec7429d50fa"
+            ],
+            "version": "==0.12.2"
+        },
+        "msgpack": {
+            "hashes": [
+                "sha256:002b5c72b6cd9b4bafd790f364b8480e859b4712e91f43014fe01e4f957b8467",
+                "sha256:0a68d3ac0104e2d3510de90a1091720157c319ceeb90d74f7b5295a6bee51bae",
+                "sha256:0df96d6eaf45ceca04b3f3b4b111b86b33785683d682c655063ef8057d61fd92",
+                "sha256:0dfe3947db5fb9ce52aaea6ca28112a170db9eae75adf9339a1aec434dc954ef",
+                "sha256:0e3590f9fb9f7fbc36df366267870e77269c03172d086fa76bb4eba8b2b46624",
+                "sha256:11184bc7e56fd74c00ead4f9cc9a3091d62ecb96e97653add7a879a14b003227",
+                "sha256:112b0f93202d7c0fef0b7810d465fde23c746a2d482e1e2de2aafd2ce1492c88",
+                "sha256:1276e8f34e139aeff1c77a3cefb295598b504ac5314d32c8c3d54d24fadb94c9",
+                "sha256:1576bd97527a93c44fa856770197dec00d223b0b9f36ef03f65bac60197cedf8",
+                "sha256:1e91d641d2bfe91ba4c52039adc5bccf27c335356055825c7f88742c8bb900dd",
+                "sha256:26b8feaca40a90cbe031b03d82b2898bf560027160d3eae1423f4a67654ec5d6",
+                "sha256:2999623886c5c02deefe156e8f869c3b0aaeba14bfc50aa2486a0415178fce55",
+                "sha256:2a2df1b55a78eb5f5b7d2a4bb221cd8363913830145fad05374a80bf0877cb1e",
+                "sha256:2bb8cdf50dd623392fa75525cce44a65a12a00c98e1e37bf0fb08ddce2ff60d2",
+                "sha256:2cc5ca2712ac0003bcb625c96368fd08a0f86bbc1a5578802512d87bc592fe44",
+                "sha256:35bc0faa494b0f1d851fd29129b2575b2e26d41d177caacd4206d81502d4c6a6",
+                "sha256:3c11a48cf5e59026ad7cb0dc29e29a01b5a66a3e333dc11c04f7e991fc5510a9",
+                "sha256:449e57cc1ff18d3b444eb554e44613cffcccb32805d16726a5494038c3b93dab",
+                "sha256:462497af5fd4e0edbb1559c352ad84f6c577ffbbb708566a0abaaa84acd9f3ae",
+                "sha256:4733359808c56d5d7756628736061c432ded018e7a1dff2d35a02439043321aa",
+                "sha256:48f5d88c99f64c456413d74a975bd605a9b0526293218a3b77220a2c15458ba9",
+                "sha256:49565b0e3d7896d9ea71d9095df15b7f75a035c49be733051c34762ca95bbf7e",
+                "sha256:4ab251d229d10498e9a2f3b1e68ef64cb393394ec477e3370c457f9430ce9250",
+                "sha256:4d5834a2a48965a349da1c5a79760d94a1a0172fbb5ab6b5b33cbf8447e109ce",
+                "sha256:4dea20515f660aa6b7e964433b1808d098dcfcabbebeaaad240d11f909298075",
+                "sha256:545e3cf0cf74f3e48b470f68ed19551ae6f9722814ea969305794645da091236",
+                "sha256:63e29d6e8c9ca22b21846234913c3466b7e4ee6e422f205a2988083de3b08cae",
+                "sha256:6916c78f33602ecf0509cc40379271ba0f9ab572b066bd4bdafd7434dee4bc6e",
+                "sha256:6a4192b1ab40f8dca3f2877b70e63799d95c62c068c84dc028b40a6cb03ccd0f",
+                "sha256:6c9566f2c39ccced0a38d37c26cc3570983b97833c365a6044edef3574a00c08",
+                "sha256:76ee788122de3a68a02ed6f3a16bbcd97bc7c2e39bd4d94be2f1821e7c4a64e6",
+                "sha256:7760f85956c415578c17edb39eed99f9181a48375b0d4a94076d84148cf67b2d",
+                "sha256:77ccd2af37f3db0ea59fb280fa2165bf1b096510ba9fe0cc2bf8fa92a22fdb43",
+                "sha256:81fc7ba725464651190b196f3cd848e8553d4d510114a954681fd0b9c479d7e1",
+                "sha256:85f279d88d8e833ec015650fd15ae5eddce0791e1e8a59165318f371158efec6",
+                "sha256:9667bdfdf523c40d2511f0e98a6c9d3603be6b371ae9a238b7ef2dc4e7a427b0",
+                "sha256:a75dfb03f8b06f4ab093dafe3ddcc2d633259e6c3f74bb1b01996f5d8aa5868c",
+                "sha256:ac5bd7901487c4a1dd51a8c58f2632b15d838d07ceedaa5e4c080f7190925bff",
+                "sha256:aca0f1644d6b5a73eb3e74d4d64d5d8c6c3d577e753a04c9e9c87d07692c58db",
+                "sha256:b17be2478b622939e39b816e0aa8242611cc8d3583d1cd8ec31b249f04623243",
+                "sha256:c1683841cd4fa45ac427c18854c3ec3cd9b681694caf5bff04edb9387602d661",
+                "sha256:c23080fdeec4716aede32b4e0ef7e213c7b1093eede9ee010949f2a418ced6ba",
+                "sha256:d5b5b962221fa2c5d3a7f8133f9abffc114fe218eb4365e40f17732ade576c8e",
+                "sha256:d603de2b8d2ea3f3bcb2efe286849aa7a81531abc52d8454da12f46235092bcb",
+                "sha256:e83f80a7fec1a62cf4e6c9a660e39c7f878f603737a0cdac8c13131d11d97f52",
+                "sha256:eb514ad14edf07a1dbe63761fd30f89ae79b42625731e1ccf5e1f1092950eaa6",
+                "sha256:eba96145051ccec0ec86611fe9cf693ce55f2a3ce89c06ed307de0e085730ec1",
+                "sha256:ed6f7b854a823ea44cf94919ba3f727e230da29feb4a99711433f25800cf747f",
+                "sha256:f0029245c51fd9473dc1aede1160b0a29f4a912e6b1dd353fa6d317085b219da",
+                "sha256:f5d869c18f030202eb412f08b28d2afeea553d6613aee89e200d7aca7ef01f5f",
+                "sha256:fb62ea4b62bfcb0b380d5680f9a4b3f9a2d166d9394e9bbd9666c0ee09a3645c",
+                "sha256:fcb8a47f43acc113e24e910399376f7277cf8508b27e5b88499f053de6b115a8"
+            ],
+            "version": "==1.0.4"
+        },
+        "pymongo": {
+            "hashes": [
+                "sha256:045408d04228987b1d4921ff6dfc3a5431cc6067400833a8bbdd050248d1e01b",
+                "sha256:0d218cb7f8828151909a8ca8365304968dd136cd4a178951a49766e35878f0bf",
+                "sha256:0dc85be60495a18714f3807266f5e88ad3a517e096be5ac3e0560a3fc1429031",
+                "sha256:177f751577109dca799746190fc261af5fc4538af60a297d772370c015475295",
+                "sha256:1b7091ac8ca82c03e471b0c9482484b2e11c26fe13b6759534ca213c11eb13a5",
+                "sha256:238541f6defbfea8725c5c30af13dcf9800c7f683bba2dde6c4b1a908f5da331",
+                "sha256:2c8ab15928468ddae7a9fb474420a68c59a5e304910e5b3ba6bf66bd79f55e73",
+                "sha256:2cb0148f197891cce964b53192225eee7ffac61ae39311c3447592eee4474b98",
+                "sha256:2e22273a601d64dbb858ab39d66cf777b07f1b3df32db5f8802fa4020870e8a5",
+                "sha256:31e8713bfd1c68bada3c1b32101748204192286566e4ea7f720163193efcb497",
+                "sha256:3291394a77addc70afda8615c29509fd32d870641f95c4411ce3ce2b84a52a24",
+                "sha256:3982bdef9f111ad3bf803629e02a3369d8b120c7fdd2477cbfeb1718799fe28a",
+                "sha256:3b38723daca6d8e97593a9eba75d55753b23b0f45f97a54c61739b3fb95ab64d",
+                "sha256:3e6929153273d5239ac63faa70486837ba51eedf58f1e8f9b7b9ab7ec8add1c3",
+                "sha256:44449e3c49d7a5d0fd9915c3e28119f28e62ed912379a973cd359c99ba73a6c2",
+                "sha256:4a37b574243b727f12cdc3e2721238dfe891ef8642d78ab93be3a8fee60e5420",
+                "sha256:5223abea94bbf502e5fbc2c7c2f34c7d82b3feb6f3a25d7d2b01869a8c814539",
+                "sha256:5229009e64b1b2d6281108c8596ae349b677be0d7087ad1e258aefd4f1a2d27f",
+                "sha256:52f636c67f8aab3b9736e4f2e1f366cb96f28f6a00baebe0885a919830866130",
+                "sha256:53e598ee484e5fc7629c9b222c0f0c7204e8c54428cdcfd94b3a851eeee28061",
+                "sha256:5973b16f82c4ff64be8dfca703920c33eb70fa0e450b06fcaf045bb0b78777ed",
+                "sha256:5a1c8e81d4090113a13d7ef95d9f77f3ab518d039cbfdaff408c37911acaba41",
+                "sha256:5bec39cbfb9367884d67a866f10c4662d8a018a9f85ae84a1e16031a6a00f6d3",
+                "sha256:60c43e6aa02c7bdfb7b99de8c1c656e14b42ea543e1cf2dbd721a272e3b8283d",
+                "sha256:6238448e77b112e90e653f20ada0c9377e4ac5d4174c9007c2d898fcddd1630c",
+                "sha256:64cdc72149ee345caa36705f161615b98adfd5c7f3200d1f87a52c87d3d4252e",
+                "sha256:69805e3ef5e80b37d578f55f898df7824d2a6287bfd63a7694d6ededb8aaa0ab",
+                "sha256:6f8b007eb7fc702806e0e50c0d723fbd086505be30baaed236df88d9e735d03c",
+                "sha256:7354c272eaf249581ee5278d8cddd03c86daa3bf25bec0eb1a281951db72034b",
+                "sha256:74bf7085e69271fe30b98492258b9a3723046e7a1a7f4d16de3df528e1cfb7ff",
+                "sha256:77037e37b33e93aa3f3998cd81d8256cd4c59eea79802601b3efbc0600f6618c",
+                "sha256:774d1b6a7cd1bbd34846cd3301a01dd4eb2ffe0bf19ebd7da79f381207713d86",
+                "sha256:7e4b3a51102a3d62fbc419470fde4d1d9744963c7235573eba4cd13c73211d68",
+                "sha256:7edbff4630058ad185cd520bbad0e528f544101e8bfa23cfd7f131031d6a81b0",
+                "sha256:83ec44c587afd8c0d4582364d5379b560bfade5f3a560d089cc14c8d79e1295f",
+                "sha256:8832b9424346c97aefd15d9c264e7f51e5b04835a57f25962cdb59f7ebd60def",
+                "sha256:8f2ac2c26b04936aa1fe6bf1ff9ff68398eda38c8ef045040174f7e64d2f7147",
+                "sha256:92b0dbc877721da8e77a8db0dfb0a9e09800d5080dc82e9e8494188b294cb263",
+                "sha256:949aaba1ad973941e9a8dd91607e474e9ce4746dac4679d05d0115bbe2eabc53",
+                "sha256:965fce3efdedaf80380a839566b04592d29c2b82100cb0fcfe2f0ecc9f2ce242",
+                "sha256:9dea8843b6d99edd6499160ec66c3772284e68d272101f356adadcb3b973287a",
+                "sha256:9e00894f1edaa85dff7d33d8a6df7d8eab04d8783c04c0654e0ec4b89bba3ae8",
+                "sha256:a057f9bc3a625142f768c4eba2c5b2dd0fde7504c655b92864fe2a2952ea6786",
+                "sha256:a13d1c6658059171a6a4f6c0a6883a15f4edbddd602759b7664ef1d155a27c5e",
+                "sha256:a701533c5a24f02a5735f60ea6fb723fa8c3319aad17d6062546481e4fa617c3",
+                "sha256:a8bd81e729ec5a5f333a930e157e37f3f1d2c5bcd7276080d3f5c0b9bcb49599",
+                "sha256:b5232fa63d29c6748d1d379e6338430f5dcaa87c0c1abca02d9ca40a9af004d1",
+                "sha256:b58bf8b4053260ce5a4847f10f607107f8b5d33ffa0d2d18b5fbaa6cf9acc994",
+                "sha256:b74e8784c810b8c9b1fdd511581fff085699e564707c4d696d00000d92b7e2a5",
+                "sha256:bd5d76ec106056ebe2cef9d5e4b7763572a90d14b97edaab25a93d6014cd327c",
+                "sha256:be8d65ff7768821d41d76e3d65a69fe25acd2080f9551306ea5598b2c308663d",
+                "sha256:c3fe1f1750afd3024dc7fdcdc730162df013f311038aa5d198f4624fa4df9c0e",
+                "sha256:c42c987b5854ea3c5a74009a905529c5045eb2a44fec793f8055e7a65f4b205e",
+                "sha256:c476103e685c80f5d59b06daf25c25c9afd1b8f102c24be8eb27f91b38e21e5b",
+                "sha256:c58cda2e1347b087c169e6fdbe184a273522214c7e9607b7d66accee119d552a",
+                "sha256:c5bf1efc65eba07aa564e22c20cacb8b38463286405ef0976a6ff23cd78a9cea",
+                "sha256:c67e29a22a1e27f5a59065792a32fee8dab9d9f716fac34041be8c55b22c93f1",
+                "sha256:cafafee3c806c44762c4b0a8119d147de742f82eb6dd12c6dabe868f38b751d9",
+                "sha256:d152e91d298a276f53864b42d24f170dac0dc4ce0777ac5a06557820ea0a8f64",
+                "sha256:d241ab2d22eb0fdec26a8f1135320d711c300aa961c3fea07ca9675833bff46d",
+                "sha256:d69f6a20923a37ac724d945e037262a18ba3a6a6fdda4cf893cbbe7a597cbfab",
+                "sha256:dbba77bc0b706c7ee496fc75a6c6ed406d85f6091d5fec488a8944c3828e6462",
+                "sha256:dbdc1f8ccb94d46ca1e92c31d2fa1df88ec2015237f537b1dad19d05de9ccf24",
+                "sha256:de7972a622b3cf48181ff1411e9a854b31988d5f283bb693f7413a56d1b9491c",
+                "sha256:e20c4100a15a4359aa29aeae84b68281c72456a6ada05f02830c3214aa616189",
+                "sha256:e3302b083ae954971c1293321c2c4d8cef53113083675b454feebd825fea1f75",
+                "sha256:e3aaffdac7456a5d2b759c129dc6d9f6d995d293e3aa9fafc810943782ca2559",
+                "sha256:e7986e293b02b4ac23694527cc23f14218b1287896227348fc83d52ff10c308c",
+                "sha256:e8e7baa22760a2b694ce5e5d33bc68c080ad00019125564e1c2450846e26fa55",
+                "sha256:eac112595ea1e8e4320dfc37e58d55f7937ed837bba7054cadd7e4578e9d275b",
+                "sha256:ecf19131972dad04e1254516f35d9e43d97929f282c7e3ad50eb313f80aae2cc",
+                "sha256:ed68e9b94bda394c5100cbc5efbf95340392794a1c56ccbab498c829fae56830",
+                "sha256:edf39f13633f5c429dcb4dc6db53916a702a8b9e5a3d277d72180a141030e3f8",
+                "sha256:f17e37e2e4fa3f68fcff2cc4e70fca1d3e2a938097133281084c28f382f9798b",
+                "sha256:f1a173deee5152c235b9d47fabcd85b2d8ef7f36f7c091bffcb37433168a82db",
+                "sha256:f2f7aedae4d938e0fe824e2d2d392f633d728e9ff36d5614879d64272783a67c",
+                "sha256:f36dac80c71e97583309408db2ae243f20e3fd2b25a86381e63434772aad6214",
+                "sha256:f479ca915db27ef719369090645c24fcca0b16e7ff1a929b94137aa8a9bb84cf",
+                "sha256:f843732762cce0cff996148da2eaf8855fd739ba90bc4a322f9c2f6d31d010b3",
+                "sha256:f9f64e25deec05ce224a4b9ebee087b04d9fcc24c2df1ecea91eb1a2ff9608a6",
+                "sha256:fc5d6f9807d7dcc3d554672551c5982c7f68e317a8d79e66c33d3aa53a6044d1",
+                "sha256:fcce0e4da390db121eedb4867b84ecc38e57f2d6be5dfd9b2dee5ce69c65b9da",
+                "sha256:fd7e75547ec10e6aa1729e65fdf992c63652e4ed8d3c0bb66da19fc892c21e2c"
+            ],
+            "markers": "python_full_version >= '3.6.2'",
+            "version": "==4.1.0"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:063df5763652e21de43de7d9e00ccf239f953a832941e37be541614732cdfc93",
+                "sha256:88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.7.5"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983",
+                "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"
+            ],
+            "markers": "python_version >= '3.7' and python_version < '4'",
+            "version": "==2.28.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.16.0"
+        },
+        "ujson": {
+            "hashes": [
+                "sha256:04a8c388b2d16316df3365c81f368955662581f6a4ff033e9aba2dd1ffc9e05e",
+                "sha256:080da13f81740c076e5f16c254a10d0e32f45d225a5e6b0687a86493cfcfbafb",
+                "sha256:0b47a138203bb06bdac03b2a89ac9b2993fd32cb7daded06c966dd84300a5786",
+                "sha256:102b8eb5e15e6c5537426414d180c28dbf0489e51f7c22b706511ac84aae4458",
+                "sha256:11f735870f189bff1841c720115226894415ab6a7796dee8ab46bc767ea2e743",
+                "sha256:163191b88842d874e081707d35de2e205e0e396e70fd068d1038879bca8b17ad",
+                "sha256:25522c674b35c33f375586ac98d92ce731e79059424507ecbccbfcbce832d597",
+                "sha256:27a254a150e46980608b16ef3b609e703173492cfa738f4644c81d7e7d77494c",
+                "sha256:2c04456de1fc92cc7062904c176c74e6ea220469b949508be42e819646a28457",
+                "sha256:2c7712da662b92f80442a8efc0df09cea3a5efb42b0dd6a642e36b1b40a260d4",
+                "sha256:350a3010db0045e1306bbdf889d1bdaee9bb095856c317716f0a74108cf4afe9",
+                "sha256:468d7d8dcbafc3fd40cc73e4a533a7a1d4f935f605c15ae6cac32c6d53c4c6aa",
+                "sha256:489d495431c80dc0048c4551a0d6cdbf1209e2d274f47c3f72415c91842eeb68",
+                "sha256:49ce8521b0cdf210481bd89887fd1bd0a975f66088b1256dafc77c67c8ccb89d",
+                "sha256:4d1ed3897e45477b2a4a1371186df299b13938d4d44d850953a4bb0ea4cb38f3",
+                "sha256:54ee7c46615b42f7ae9dca90f54d204a4d2041a4c926b08fffa953aa3a246e54",
+                "sha256:584c558c23ddc21f5b07d2c54ee527731bd9716101c27829023ab7f3ffbaa8fc",
+                "sha256:6227597d0201ceadc902d1a8edaffaeb244050b197368ed25e6f6be0df170a6f",
+                "sha256:6677bee8690c71f5e6cf519a6d8400f04fbd3ff9f6c50f35f1b664bc94546f84",
+                "sha256:6b455a62bd20e890b2124a65df45313b4292dbea851ef38574e5e2de94691ad5",
+                "sha256:6c5bbe6de6c9a5fe8dca56e36fb5c4a42e1a01d4aae1ac20cd8d7d82ccff9430",
+                "sha256:729af63e4de30c54b527b54b4100266f79833c1e8ba35e784f01b44c2aca88d8",
+                "sha256:754e9da96a24535ae5ab2a52e1d1dfc65a6a717c14063855b83f327fdf2173ea",
+                "sha256:75a886bd89d8e5a004a39a6c5dc8a43bb7fcf05129d2dccd16a59602a612823a",
+                "sha256:8c3f7578a62d9255650ef32e78d3345e98262e064c9ba3f205311b4c9eb507a6",
+                "sha256:90de04391916c5adc7bbcc69bd778e263ed45cc83c070099cb07ed25068d6a12",
+                "sha256:940f35e9a0969440621445dbb6adffaa2cea77d0262abc74fce78704120c4534",
+                "sha256:9acc874128baddeff908736db251597e4cbd007a384730377a59a61b08886599",
+                "sha256:a1a55b3310632661a03ce68ccfb92264031aea21626d6fa5c8f6c32e769be7b6",
+                "sha256:a3c6798035b574ceba747de83f3223a622622b7ab77a24f8b4fbea2cb92f14b0",
+                "sha256:a5e374e793b0a3c7df20ee4c8234e89859ddb2b2821cc3300ae94ab5b08fa6d0",
+                "sha256:a6f3ad3b11578bc4e25d5bd256c938fe2c7c015d8f504bc7835f127ed26a0818",
+                "sha256:b3671e1dfc49a4b4453d89fd7438aa9d7cca28afe329c70eba84e2a5778dbf3f",
+                "sha256:b5fcbaabf3d115cb816eb165f3fa5de5c5bc795473a554ae55620d134ddf2d36",
+                "sha256:bc1a619bad9894dad144184b735c98179c7d92d7b40fbda28eb8b0857bdfdf52",
+                "sha256:be909514a47b6272e34cd1213feee324ca35a354e07f1ae3aba12d3694a5279f",
+                "sha256:c519743a53bbe8aac6b743bcf50eb83057d1e0341e1ca8f8491f729a885af640",
+                "sha256:c549d5a7652c3a0dd00ef6ff910fb01878bc116c66c94ac455a55cffa32cc229",
+                "sha256:d1e5c635b7c3465ab8d2e3dc97c341ef1801c53a378f1d1d4cb934f6c90ec66c",
+                "sha256:d2357ce7d93eadd29b6efbe72228809948cc59ec6682c20fa6de08aeef1703f8",
+                "sha256:d38c2a58c892c680080b22b59eebd77b7c6f4ae24361111fba115f9ed3651dcf",
+                "sha256:d57a87bbc77d66b8a2b74bab66357c3bb6194f5d248f1053fb8044787abde73f",
+                "sha256:d9b1c3d2b22c040a81ff4e5927ce307919f7ac8bf888afded714d925edc8d0a4",
+                "sha256:dc5fd1d5b48edd3cc64e89ea94abe231509fdc938bdeafafe9aef3a05810159f",
+                "sha256:dc71ead5706e81fdf1054c8c11e4aaab43527da450a2701213c20717852d1a51",
+                "sha256:e53388fb092197cb8f956673792aca994872917d897ca42a0abf7a35e293575a",
+                "sha256:e991b7b3a08ac9e9d3a51589ef1c359c8d44ece730351cfac055684bf3787372",
+                "sha256:ed78a5b169ece75a1e1368935ce6ab051dcbcd5c158b9796b2f1fa6cc467a651",
+                "sha256:ef868bf01851869a26c0ca5f88036903836c3a6b463c74d96b37f294f6bdeea4",
+                "sha256:fb4555df1fe018806ba14cc38786269c8e213930103c6d0ac81e506d09d1de7e"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==5.2.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14",
+                "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==1.26.9"
+        }
+    },
+    "develop": {
+        "alabaster": {
+            "hashes": [
+                "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359",
+                "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"
+            ],
+            "version": "==0.7.12"
+        },
+        "babel": {
+            "hashes": [
+                "sha256:7614553711ee97490f732126dc077f8d0ae084ebc6a96e23db1482afabdb2c51",
+                "sha256:ff56f4892c1c4bf0d814575ea23471c230d544203c7748e8c68f0089478d48eb"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2.10.3"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d",
+                "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"
+            ],
+            "markers": "python_full_version >= '3.6.0'",
+            "version": "==2022.6.15"
+        },
+        "charset-normalizer": {
+            "hashes": [
+                "sha256:5189b6f22b01957427f35b6a08d9a0bc45b46d3788ef5a92e978433c7a35f8a5",
+                "sha256:575e708016ff3a5e3681541cb9d79312c416835686d054a23accb873b254f413"
+            ],
+            "markers": "python_full_version >= '3.6.0'",
+            "version": "==2.1.0"
+        },
+        "coverage": {
+            "hashes": [
+                "sha256:01c5615d13f3dd3aa8543afc069e5319cfa0c7d712f6e04b920431e5c564a749",
+                "sha256:106c16dfe494de3193ec55cac9640dd039b66e196e4641fa8ac396181578b982",
+                "sha256:129cd05ba6f0d08a766d942a9ed4b29283aff7b2cccf5b7ce279d50796860bb3",
+                "sha256:145f296d00441ca703a659e8f3eb48ae39fb083baba2d7ce4482fb2723e050d9",
+                "sha256:1480ff858b4113db2718848d7b2d1b75bc79895a9c22e76a221b9d8d62496428",
+                "sha256:269eaa2c20a13a5bf17558d4dc91a8d078c4fa1872f25303dddcbba3a813085e",
+                "sha256:26dff09fb0d82693ba9e6231248641d60ba606150d02ed45110f9ec26404ed1c",
+                "sha256:2bd9a6fc18aab8d2e18f89b7ff91c0f34ff4d5e0ba0b33e989b3cd4194c81fd9",
+                "sha256:309ce4a522ed5fca432af4ebe0f32b21d6d7ccbb0f5fcc99290e71feba67c264",
+                "sha256:3384f2a3652cef289e38100f2d037956194a837221edd520a7ee5b42d00cc605",
+                "sha256:342d4aefd1c3e7f620a13f4fe563154d808b69cccef415415aece4c786665397",
+                "sha256:39ee53946bf009788108b4dd2894bf1349b4e0ca18c2016ffa7d26ce46b8f10d",
+                "sha256:4321f075095a096e70aff1d002030ee612b65a205a0a0f5b815280d5dc58100c",
+                "sha256:4803e7ccf93230accb928f3a68f00ffa80a88213af98ed338a57ad021ef06815",
+                "sha256:4ce1b258493cbf8aec43e9b50d89982346b98e9ffdfaae8ae5793bc112fb0068",
+                "sha256:664a47ce62fe4bef9e2d2c430306e1428ecea207ffd68649e3b942fa8ea83b0b",
+                "sha256:75ab269400706fab15981fd4bd5080c56bd5cc07c3bccb86aab5e1d5a88dc8f4",
+                "sha256:83c4e737f60c6936460c5be330d296dd5b48b3963f48634c53b3f7deb0f34ec4",
+                "sha256:84631e81dd053e8a0d4967cedab6db94345f1c36107c71698f746cb2636c63e3",
+                "sha256:84e65ef149028516c6d64461b95a8dbcfce95cfd5b9eb634320596173332ea84",
+                "sha256:865d69ae811a392f4d06bde506d531f6a28a00af36f5c8649684a9e5e4a85c83",
+                "sha256:87f4f3df85aa39da00fd3ec4b5abeb7407e82b68c7c5ad181308b0e2526da5d4",
+                "sha256:8c08da0bd238f2970230c2a0d28ff0e99961598cb2e810245d7fc5afcf1254e8",
+                "sha256:961e2fb0680b4f5ad63234e0bf55dfb90d302740ae9c7ed0120677a94a1590cb",
+                "sha256:9b3e07152b4563722be523e8cd0b209e0d1a373022cfbde395ebb6575bf6790d",
+                "sha256:a7f3049243783df2e6cc6deafc49ea123522b59f464831476d3d1448e30d72df",
+                "sha256:bf5601c33213d3cb19d17a796f8a14a9eaa5e87629a53979a5981e3e3ae166f6",
+                "sha256:cec3a0f75c8f1031825e19cd86ee787e87cf03e4fd2865c79c057092e69e3a3b",
+                "sha256:d42c549a8f41dc103a8004b9f0c433e2086add8a719da00e246e17cbe4056f72",
+                "sha256:d67d44996140af8b84284e5e7d398e589574b376fb4de8ccd28d82ad8e3bea13",
+                "sha256:d9c80df769f5ec05ad21ea34be7458d1dc51ff1fb4b2219e77fe24edf462d6df",
+                "sha256:e57816f8ffe46b1df8f12e1b348f06d164fd5219beba7d9433ba79608ef011cc",
+                "sha256:ee2ddcac99b2d2aec413e36d7a429ae9ebcadf912946b13ffa88e7d4c9b712d6",
+                "sha256:f02cbbf8119db68455b9d763f2f8737bb7db7e43720afa07d8eb1604e5c5ae28",
+                "sha256:f1d5aa2703e1dab4ae6cf416eb0095304f49d004c39e9db1d86f57924f43006b",
+                "sha256:f5b66caa62922531059bc5ac04f836860412f7f88d38a476eda0a6f11d4724f4",
+                "sha256:f69718750eaae75efe506406c490d6fc5a6161d047206cc63ce25527e8a3adad",
+                "sha256:fb73e0011b8793c053bfa85e53129ba5f0250fdc0392c1591fd35d915ec75c46",
+                "sha256:fd180ed867e289964404051a958f7cccabdeed423f91a899829264bb7974d3d3",
+                "sha256:fdb6f7bd51c2d1714cea40718f6149ad9be6a2ee7d93b19e9f00934c0f2a74d9",
+                "sha256:ffa9297c3a453fba4717d06df579af42ab9a28022444cae7fa605af4df612d54"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==6.4.1"
+        },
+        "distlib": {
+            "hashes": [
+                "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b",
+                "sha256:e4b58818180336dc9c529bfb9a0b58728ffc09ad92027a3f30b7cd91e3458579"
+            ],
+            "version": "==0.3.4"
+        },
+        "docutils": {
+            "hashes": [
+                "sha256:23010f129180089fbcd3bc08cfefccb3b890b0050e1ca00c867036e9d161b98c",
+                "sha256:679987caf361a7539d76e584cbeddc311e3aee937877c87346f31debc63e9d06"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==0.18.1"
+        },
+        "filelock": {
+            "hashes": [
+                "sha256:37def7b658813cda163b56fc564cdc75e86d338246458c4c28ae84cabefa2404",
+                "sha256:3a0fd85166ad9dbab54c9aec96737b744106dc5f15c0b09a6744a445299fcf04"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.7.1"
+        },
+        "flake8": {
+            "hashes": [
+                "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d",
+                "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"
+            ],
+            "index": "pypi",
+            "version": "==4.0.1"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
+                "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==3.3"
+        },
+        "imagesize": {
+            "hashes": [
+                "sha256:0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b",
+                "sha256:69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.4.1"
+        },
+        "jinja2": {
+            "hashes": [
+                "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852",
+                "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.1.2"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:0212a68688482dc52b2d45013df70d169f542b7394fc744c02a57374a4207003",
+                "sha256:089cf3dbf0cd6c100f02945abeb18484bd1ee57a079aefd52cffd17fba910b88",
+                "sha256:10c1bfff05d95783da83491be968e8fe789263689c02724e0c691933c52994f5",
+                "sha256:33b74d289bd2f5e527beadcaa3f401e0df0a89927c1559c8566c066fa4248ab7",
+                "sha256:3799351e2336dc91ea70b034983ee71cf2f9533cdff7c14c90ea126bfd95d65a",
+                "sha256:3ce11ee3f23f79dbd06fb3d63e2f6af7b12db1d46932fe7bd8afa259a5996603",
+                "sha256:421be9fbf0ffe9ffd7a378aafebbf6f4602d564d34be190fc19a193232fd12b1",
+                "sha256:43093fb83d8343aac0b1baa75516da6092f58f41200907ef92448ecab8825135",
+                "sha256:46d00d6cfecdde84d40e572d63735ef81423ad31184100411e6e3388d405e247",
+                "sha256:4a33dea2b688b3190ee12bd7cfa29d39c9ed176bda40bfa11099a3ce5d3a7ac6",
+                "sha256:4b9fe39a2ccc108a4accc2676e77da025ce383c108593d65cc909add5c3bd601",
+                "sha256:56442863ed2b06d19c37f94d999035e15ee982988920e12a5b4ba29b62ad1f77",
+                "sha256:671cd1187ed5e62818414afe79ed29da836dde67166a9fac6d435873c44fdd02",
+                "sha256:694deca8d702d5db21ec83983ce0bb4b26a578e71fbdbd4fdcd387daa90e4d5e",
+                "sha256:6a074d34ee7a5ce3effbc526b7083ec9731bb3cbf921bbe1d3005d4d2bdb3a63",
+                "sha256:6d0072fea50feec76a4c418096652f2c3238eaa014b2f94aeb1d56a66b41403f",
+                "sha256:6fbf47b5d3728c6aea2abb0589b5d30459e369baa772e0f37a0320185e87c980",
+                "sha256:7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b",
+                "sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812",
+                "sha256:8dc1c72a69aa7e082593c4a203dcf94ddb74bb5c8a731e4e1eb68d031e8498ff",
+                "sha256:8e3dcf21f367459434c18e71b2a9532d96547aef8a871872a5bd69a715c15f96",
+                "sha256:8e576a51ad59e4bfaac456023a78f6b5e6e7651dcd383bcc3e18d06f9b55d6d1",
+                "sha256:96e37a3dc86e80bf81758c152fe66dbf60ed5eca3d26305edf01892257049925",
+                "sha256:97a68e6ada378df82bc9f16b800ab77cbf4b2fada0081794318520138c088e4a",
+                "sha256:99a2a507ed3ac881b975a2976d59f38c19386d128e7a9a18b7df6fff1fd4c1d6",
+                "sha256:a49907dd8420c5685cfa064a1335b6754b74541bbb3706c259c02ed65b644b3e",
+                "sha256:b09bf97215625a311f669476f44b8b318b075847b49316d3e28c08e41a7a573f",
+                "sha256:b7bd98b796e2b6553da7225aeb61f447f80a1ca64f41d83612e6139ca5213aa4",
+                "sha256:b87db4360013327109564f0e591bd2a3b318547bcef31b468a92ee504d07ae4f",
+                "sha256:bcb3ed405ed3222f9904899563d6fc492ff75cce56cba05e32eff40e6acbeaa3",
+                "sha256:d4306c36ca495956b6d568d276ac11fdd9c30a36f1b6eb928070dc5360b22e1c",
+                "sha256:d5ee4f386140395a2c818d149221149c54849dfcfcb9f1debfe07a8b8bd63f9a",
+                "sha256:dda30ba7e87fbbb7eab1ec9f58678558fd9a6b8b853530e176eabd064da81417",
+                "sha256:e04e26803c9c3851c931eac40c695602c6295b8d432cbe78609649ad9bd2da8a",
+                "sha256:e1c0b87e09fa55a220f058d1d49d3fb8df88fbfab58558f1198e08c1e1de842a",
+                "sha256:e72591e9ecd94d7feb70c1cbd7be7b3ebea3f548870aa91e2732960fa4d57a37",
+                "sha256:e8c843bbcda3a2f1e3c2ab25913c80a3c5376cd00c6e8c4a86a89a28c8dc5452",
+                "sha256:efc1913fd2ca4f334418481c7e595c00aad186563bbc1ec76067848c7ca0a933",
+                "sha256:f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a",
+                "sha256:fc7b548b17d238737688817ab67deebb30e8073c95749d55538ed473130ec0c7"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.1.1"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
+        },
+        "nose2": {
+            "hashes": [
+                "sha256:6d208d7d6ec9f9d55c74dac81c9394bc3906dbef81a8ca5420b2b9b7f8e69de9",
+                "sha256:d37e75e3010bb4739fe6045a29d4c633ac3146cb5704ee4e4a9e4abeceb2dee3"
+            ],
+            "index": "pypi",
+            "version": "==0.11.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
+                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==21.3"
+        },
+        "platformdirs": {
+            "hashes": [
+                "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788",
+                "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.5.2"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159",
+                "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.0.0"
+        },
+        "py": {
+            "hashes": [
+                "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719",
+                "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.11.0"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20",
+                "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==2.8.0"
+        },
+        "pyflakes": {
+            "hashes": [
+                "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c",
+                "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.4.0"
+        },
+        "pygments": {
+            "hashes": [
+                "sha256:5eb116118f9612ff1ee89ac96437bb6b49e8f04d8a13b514ba26f620208e26eb",
+                "sha256:dc9c10fb40944260f6ed4c688ece0cd2048414940f1cea51b8b226318411c519"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2.12.0"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
+                "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"
+            ],
+            "markers": "python_full_version >= '3.6.8'",
+            "version": "==3.0.9"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7",
+                "sha256:e68985985296d9a66a881eb3193b0906246245294a881e7c8afe623866ac6a5c"
+            ],
+            "version": "==2022.1"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983",
+                "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"
+            ],
+            "markers": "python_version >= '3.7' and python_version < '4'",
+            "version": "==2.28.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.16.0"
+        },
+        "snowballstemmer": {
+            "hashes": [
+                "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1",
+                "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"
+            ],
+            "version": "==2.2.0"
+        },
+        "sphinx": {
+            "hashes": [
+                "sha256:565a72dd39dd6ea2e8c548d34c127c981e4bcaead69a2c456a6e33ef69151ace",
+                "sha256:9d93711a0f71c2a21ee44e4fd844f9990b679c9eef951f60d22b19ad9e6e929d"
+            ],
+            "index": "pypi",
+            "version": "==1.5.6"
+        },
+        "sphinx-rtd-theme": {
+            "hashes": [
+                "sha256:273846f8aacac32bf9542365a593b495b68d8035c2e382c9ccedcac387c9a0a1",
+                "sha256:3c38d037713bd78043486eea5bf771d71ed697ec25c09e16f49e44887f7fe184",
+                "sha256:46c2ca8b482b0398b9621bb5a8ec7c9c5c7226926e5363e18d744f5f0d39d78f"
+            ],
+            "index": "pypi",
+            "version": "==0.1.9"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
+                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.10.2"
+        },
+        "tox": {
+            "hashes": [
+                "sha256:c138327815f53bc6da4fe56baec5f25f00622ae69ef3fe4e1e385720e22486f9",
+                "sha256:c38e15f4733683a9cc0129fba078633e07eb0961f550a010ada879e95fb32632"
+            ],
+            "index": "pypi",
+            "version": "==3.25.1"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14",
+                "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==1.26.9"
+        },
+        "virtualenv": {
+            "hashes": [
+                "sha256:288171134a2ff3bfb1a2f54f119e77cd1b81c29fc1265a2356f3e8d14c7d58c4",
+                "sha256:b30aefac647e86af6d82bfc944c556f8f1a9c90427b2fb4e3bfbf338cb82becf"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==20.15.1"
+        }
+    }
+}

--- a/elex/api/models.py
+++ b/elex/api/models.py
@@ -872,6 +872,7 @@ class Election(APElection):
 
         self.testresults = kwargs.get('testresults', False)
         self.liveresults = kwargs.get('liveresults', False)
+        self.resultstype = kwargs.get('resultstype')
         self.electiondate = kwargs.get('electiondate', None)
         self.national = kwargs.get('national', None)
         self.api_key = kwargs.get('api_key', None)
@@ -1055,7 +1056,7 @@ class Election(APElection):
         raw_races = self.get_raw_races(
             omitResults=True,
             level="ru",
-            test=self.testresults,
+            resultstype=self.resultstype,
             national=self.national,
             officeID=self.officeids,
             apiKey=self.api_key
@@ -1075,7 +1076,7 @@ class Election(APElection):
         raw_races = self.get_raw_races(
             omitResults=False,
             level="ru",
-            test=self.testresults,
+            resultstype=self.resultstype,
             national=self.national,
             officeID=self.officeids,
             apiKey=self.api_key
@@ -1114,7 +1115,7 @@ class Election(APElection):
             omitResults=False,
             level=self.resultslevel,
             setzerocounts=self.setzerocounts,
-            test=self.testresults,
+            resultstype=self.resultstype,
             national=self.national,
             officeID=self.officeids,
             apiKey=self.api_key
@@ -1133,7 +1134,7 @@ class Election(APElection):
         raw_races = self.get_raw_races(
             omitResults=True,
             level="ru",
-            test=self.testresults,
+            resultstype=self.resultstype,
             national=self.national,
             officeID=self.officeids,
             apiKey=self.api_key
@@ -1155,7 +1156,7 @@ class Election(APElection):
         raw_races = self.get_raw_races(
             omitResults=True,
             level="ru",
-            test=self.testresults,
+            resultstype=self.resultstype,
             national=self.national,
             apiKey=self.api_key
         )

--- a/elex/api/models.py
+++ b/elex/api/models.py
@@ -324,6 +324,7 @@ class CandidateReportingUnit(APElection):
         self.precinctsreporting = kwargs.get('precinctsreporting', 0)
         self.precinctstotal = kwargs.get('precinctstotal', 0)
         self.precinctsreportingpct = kwargs.get('precinctsreportingpct', 0.0)
+        self.eevp = kwargs.get('eevp', None)
         self.uncontested = kwargs.get('uncontested', False)
         self.test = kwargs.get('test', False)
         self.raceid = kwargs.get('raceid', None)
@@ -409,6 +410,7 @@ class CandidateReportingUnit(APElection):
             ('precinctsreporting', self.precinctsreporting),
             ('precinctsreportingpct', self.precinctsreportingpct),
             ('precinctstotal', self.precinctstotal),
+            ('eevp', self.eevp),
             ('reportingunitid', self.reportingunitid),
             ('reportingunitname', self.reportingunitname),
             ('runoff', self.runoff),
@@ -477,6 +479,8 @@ class ReportingUnit(APElection):
 
         self.precinctsreportingpct = kwargs.get('precinctsReportingPct', 0.0)\
             * 0.01
+
+        self.eevp = kwargs.get('eevp', None)
 
         if kwargs.get('precinctsreportingpct', None):
             self.precinctsreportingpct = kwargs['precinctsreportingpct']
@@ -585,6 +589,7 @@ class ReportingUnit(APElection):
             ('precinctsreporting', self.precinctsreporting),
             ('precinctsreportingpct', self.precinctsreportingpct),
             ('precinctstotal', self.precinctstotal),
+            ('eevp', self.eevp),
             ('raceid', self.raceid),
             ('racetype', self.racetype),
             ('racetypeid', self.racetypeid),

--- a/elex/api/models.py
+++ b/elex/api/models.py
@@ -327,6 +327,7 @@ class CandidateReportingUnit(APElection):
         self.eevp = kwargs.get('eevp', None)
         self.uncontested = kwargs.get('uncontested', False)
         self.test = kwargs.get('test', False)
+        self.resultstype = kwargs.get('resultstype', None)
         self.raceid = kwargs.get('raceid', None)
         self.statepostal = kwargs.get('statepostal', None)
         self.statename = kwargs.get('statename', None)
@@ -419,6 +420,7 @@ class CandidateReportingUnit(APElection):
             ('statename', self.statename),
             ('statepostal', self.statepostal),
             ('test', self.test),
+            ('resultstype', self.resultstype),
             ('uncontested', self.uncontested),
             ('votecount', self.votecount),
             ('votepct', round(self.votepct, PCT_PRECISION)),
@@ -487,6 +489,7 @@ class ReportingUnit(APElection):
 
         self.uncontested = kwargs.get('uncontested', False)
         self.test = kwargs.get('test', False)
+        self.resultstype = kwargs.get('resultstype', None)
         self.raceid = kwargs.get('raceid', None)
         self.racetype = kwargs.get('racetype', None)
         self.racetypeid = kwargs.get('racetypeid', None)
@@ -600,6 +603,7 @@ class ReportingUnit(APElection):
             ('statepostal', self.statepostal),
             ('statepostal', self.statepostal),
             ('test', self.test),
+            ('resultstype', self.resultstype),
             ('uncontested', self.uncontested),
             ('votecount', self.votecount),
         ))
@@ -616,6 +620,7 @@ class Race(APElection):
         self.statepostal = kwargs.get('statePostal', None)
         self.statename = kwargs.get('stateName', None)
         self.test = kwargs.get('test', False)
+        self.resultstype = kwargs.get('resultsType', None)
         self.raceid = kwargs.get('raceID', None)
         self.racetype = kwargs.get('raceType', None)
         self.racetypeid = kwargs.get('raceTypeID', None)
@@ -787,6 +792,7 @@ class Race(APElection):
             ('statename', self.statename),
             ('statepostal', self.statepostal),
             ('test', self.test),
+            ('resultstype', self.resultstype),
             ('uncontested', self.uncontested)
         ))
 
@@ -1045,7 +1051,8 @@ class Election(APElection):
             ('id', self.id),
             ('electiondate', self.electiondate),
             ('liveresults', self.liveresults),
-            ('testresults', self.testresults)
+            ('testresults', self.testresults),
+            ('resultstype', self.resultstype)
         ))
 
     @property

--- a/elex/api/models.py
+++ b/elex/api/models.py
@@ -326,7 +326,7 @@ class CandidateReportingUnit(APElection):
         self.precinctsreportingpct = kwargs.get('precinctsreportingpct', 0.0)
         self.eevp = kwargs.get('eevp', None)
         self.uncontested = kwargs.get('uncontested', False)
-        self.resultstype = kwargs.get('resultstype', 'l')
+        self.test = kwargs.get('test', False)
         self.raceid = kwargs.get('raceid', None)
         self.statepostal = kwargs.get('statepostal', None)
         self.statename = kwargs.get('statename', None)
@@ -418,7 +418,7 @@ class CandidateReportingUnit(APElection):
             ('seatnum', self.seatnum),
             ('statename', self.statename),
             ('statepostal', self.statepostal),
-            ('resultstype', self.resultstype),
+            ('test', self.test),
             ('uncontested', self.uncontested),
             ('votecount', self.votecount),
             ('votepct', round(self.votepct, PCT_PRECISION)),
@@ -486,7 +486,7 @@ class ReportingUnit(APElection):
             self.precinctsreportingpct = kwargs['precinctsreportingpct']
 
         self.uncontested = kwargs.get('uncontested', False)
-        self.resultstype = kwargs.get('resultstype', 'l')
+        self.test = kwargs.get('test', False)
         self.raceid = kwargs.get('raceid', None)
         self.racetype = kwargs.get('racetype', None)
         self.racetypeid = kwargs.get('racetypeid', None)
@@ -599,7 +599,7 @@ class ReportingUnit(APElection):
             ('statename', self.statename),
             ('statepostal', self.statepostal),
             ('statepostal', self.statepostal),
-            ('resultstype', self.resultstype),
+            ('test', self.test),
             ('uncontested', self.uncontested),
             ('votecount', self.votecount),
         ))
@@ -615,7 +615,7 @@ class Race(APElection):
         self.electiondate = kwargs.get('electiondate', None)
         self.statepostal = kwargs.get('statePostal', None)
         self.statename = kwargs.get('stateName', None)
-        self.resultstype = kwargs.get('resultstype', 'l')
+        self.test = kwargs.get('test', False)
         self.raceid = kwargs.get('raceID', None)
         self.racetype = kwargs.get('raceType', None)
         self.racetypeid = kwargs.get('raceTypeID', None)
@@ -786,7 +786,7 @@ class Race(APElection):
             ('seatnum', self.seatnum),
             ('statename', self.statename),
             ('statepostal', self.statepostal),
-            ('resultstype', self.resultstype),
+            ('test', self.test),
             ('uncontested', self.uncontested)
         ))
 
@@ -870,8 +870,8 @@ class Election(APElection):
         """
         self.id = None
 
+        self.testresults = kwargs.get('testresults', False)
         self.liveresults = kwargs.get('liveresults', False)
-        self.resultstype = kwargs.get('resultstype', 'l')
         self.electiondate = kwargs.get('electiondate', None)
         self.national = kwargs.get('national', None)
         self.api_key = kwargs.get('api_key', None)
@@ -1044,7 +1044,7 @@ class Election(APElection):
             ('id', self.id),
             ('electiondate', self.electiondate),
             ('liveresults', self.liveresults),
-            ('resultstype', self.resultstype)
+            ('testresults', self.testresults)
         ))
 
     @property
@@ -1055,7 +1055,7 @@ class Election(APElection):
         raw_races = self.get_raw_races(
             omitResults=True,
             level="ru",
-            resultstype=self.resultstype,
+            test=self.testresults,
             national=self.national,
             officeID=self.officeids,
             apiKey=self.api_key
@@ -1075,7 +1075,7 @@ class Election(APElection):
         raw_races = self.get_raw_races(
             omitResults=False,
             level="ru",
-            resultstype=self.resultstype,
+            test=self.testresults,
             national=self.national,
             officeID=self.officeids,
             apiKey=self.api_key
@@ -1094,6 +1094,7 @@ class Election(APElection):
         raw_races = self.get_raw_races(
             omitResults=True,
             level="ru",
+            test=self.testresults,
             national=self.national,
             officeID=self.officeids,
             apiKey=self.api_key
@@ -1113,7 +1114,7 @@ class Election(APElection):
             omitResults=False,
             level=self.resultslevel,
             setzerocounts=self.setzerocounts,
-            resultstype=self.resultstype,
+            test=self.testresults,
             national=self.national,
             officeID=self.officeids,
             apiKey=self.api_key
@@ -1132,7 +1133,7 @@ class Election(APElection):
         raw_races = self.get_raw_races(
             omitResults=True,
             level="ru",
-            resultstype=self.resultstype,
+            test=self.testresults,
             national=self.national,
             officeID=self.officeids,
             apiKey=self.api_key
@@ -1154,7 +1155,7 @@ class Election(APElection):
         raw_races = self.get_raw_races(
             omitResults=True,
             level="ru",
-            resultstype=self.resultstype,
+            test=self.testresults,
             national=self.national,
             apiKey=self.api_key
         )

--- a/elex/api/models.py
+++ b/elex/api/models.py
@@ -326,7 +326,7 @@ class CandidateReportingUnit(APElection):
         self.precinctsreportingpct = kwargs.get('precinctsreportingpct', 0.0)
         self.eevp = kwargs.get('eevp', None)
         self.uncontested = kwargs.get('uncontested', False)
-        self.test = kwargs.get('test', False)
+        self.resultstype = kwargs.get('resultstype', 'l')
         self.raceid = kwargs.get('raceid', None)
         self.statepostal = kwargs.get('statepostal', None)
         self.statename = kwargs.get('statename', None)
@@ -418,7 +418,7 @@ class CandidateReportingUnit(APElection):
             ('seatnum', self.seatnum),
             ('statename', self.statename),
             ('statepostal', self.statepostal),
-            ('test', self.test),
+            ('resultstype', self.resultstype),
             ('uncontested', self.uncontested),
             ('votecount', self.votecount),
             ('votepct', round(self.votepct, PCT_PRECISION)),
@@ -486,7 +486,7 @@ class ReportingUnit(APElection):
             self.precinctsreportingpct = kwargs['precinctsreportingpct']
 
         self.uncontested = kwargs.get('uncontested', False)
-        self.test = kwargs.get('test', False)
+        self.resultstype = kwargs.get('resultstype', 'l')
         self.raceid = kwargs.get('raceid', None)
         self.racetype = kwargs.get('racetype', None)
         self.racetypeid = kwargs.get('racetypeid', None)
@@ -599,7 +599,7 @@ class ReportingUnit(APElection):
             ('statename', self.statename),
             ('statepostal', self.statepostal),
             ('statepostal', self.statepostal),
-            ('test', self.test),
+            ('resultstype', self.resultstype),
             ('uncontested', self.uncontested),
             ('votecount', self.votecount),
         ))
@@ -615,7 +615,7 @@ class Race(APElection):
         self.electiondate = kwargs.get('electiondate', None)
         self.statepostal = kwargs.get('statePostal', None)
         self.statename = kwargs.get('stateName', None)
-        self.test = kwargs.get('test', False)
+        self.resultstype = kwargs.get('resultstype', 'l')
         self.raceid = kwargs.get('raceID', None)
         self.racetype = kwargs.get('raceType', None)
         self.racetypeid = kwargs.get('raceTypeID', None)
@@ -786,7 +786,7 @@ class Race(APElection):
             ('seatnum', self.seatnum),
             ('statename', self.statename),
             ('statepostal', self.statepostal),
-            ('test', self.test),
+            ('resultstype', self.resultstype),
             ('uncontested', self.uncontested)
         ))
 
@@ -870,8 +870,8 @@ class Election(APElection):
         """
         self.id = None
 
-        self.testresults = kwargs.get('testresults', False)
         self.liveresults = kwargs.get('liveresults', False)
+        self.resultstype = kwargs.get('resultstype', 'l')
         self.electiondate = kwargs.get('electiondate', None)
         self.national = kwargs.get('national', None)
         self.api_key = kwargs.get('api_key', None)
@@ -1044,7 +1044,7 @@ class Election(APElection):
             ('id', self.id),
             ('electiondate', self.electiondate),
             ('liveresults', self.liveresults),
-            ('testresults', self.testresults)
+            ('resultstype', self.resultstype)
         ))
 
     @property
@@ -1055,7 +1055,7 @@ class Election(APElection):
         raw_races = self.get_raw_races(
             omitResults=True,
             level="ru",
-            test=self.testresults,
+            resultstype=self.resultstype,
             national=self.national,
             officeID=self.officeids,
             apiKey=self.api_key
@@ -1075,7 +1075,7 @@ class Election(APElection):
         raw_races = self.get_raw_races(
             omitResults=False,
             level="ru",
-            test=self.testresults,
+            resultstype=self.resultstype,
             national=self.national,
             officeID=self.officeids,
             apiKey=self.api_key
@@ -1094,7 +1094,6 @@ class Election(APElection):
         raw_races = self.get_raw_races(
             omitResults=True,
             level="ru",
-            test=self.testresults,
             national=self.national,
             officeID=self.officeids,
             apiKey=self.api_key
@@ -1114,7 +1113,7 @@ class Election(APElection):
             omitResults=False,
             level=self.resultslevel,
             setzerocounts=self.setzerocounts,
-            test=self.testresults,
+            resultstype=self.resultstype,
             national=self.national,
             officeID=self.officeids,
             apiKey=self.api_key
@@ -1133,7 +1132,7 @@ class Election(APElection):
         raw_races = self.get_raw_races(
             omitResults=True,
             level="ru",
-            test=self.testresults,
+            resultstype=self.resultstype,
             national=self.national,
             officeID=self.officeids,
             apiKey=self.api_key
@@ -1155,7 +1154,7 @@ class Election(APElection):
         raw_races = self.get_raw_races(
             omitResults=True,
             level="ru",
-            test=self.testresults,
+            resultstype=self.resultstype,
             national=self.national,
             apiKey=self.api_key
         )

--- a/elex/cli/app.py
+++ b/elex/cli/app.py
@@ -19,13 +19,15 @@ class ElexBaseController(CementBaseController):
                 help='Election date (e.g. "2015-11-03"; most common date \
 formats accepted).'
             )),
-            (['-t', '--test'], dict(
-                action='store_true',
-                help='Use testing API calls'
-            )),
             (['-n', '--not-live'], dict(
                 action='store_true',
                 help='Do not use live data API calls'
+            )),
+            (['--results-type'], dict(
+                action='store',
+                help='Specify results type. `t` for test, `l` for live, `c` for certified \
+                    `b` for auto switch from live to certified.',
+                default='l'
             )),
             (['-d', '--data-file'], dict(
                 action='store',

--- a/elex/cli/app.py
+++ b/elex/cli/app.py
@@ -19,15 +19,13 @@ class ElexBaseController(CementBaseController):
                 help='Election date (e.g. "2015-11-03"; most common date \
 formats accepted).'
             )),
+            (['-t', '--test'], dict(
+                action='store_true',
+                help='Use testing API calls'
+            )),
             (['-n', '--not-live'], dict(
                 action='store_true',
                 help='Do not use live data API calls'
-            )),
-            (['--results-type'], dict(
-                action='store',
-                help='Specify results type. t for test, l for live, c for certified,\
-                    b to automatically switch from live to certified.',
-                default='l'
             )),
             (['-d', '--data-file'], dict(
                 action='store',

--- a/elex/cli/app.py
+++ b/elex/cli/app.py
@@ -19,13 +19,15 @@ class ElexBaseController(CementBaseController):
                 help='Election date (e.g. "2015-11-03"; most common date \
 formats accepted).'
             )),
-            (['-t', '--test'], dict(
-                action='store_true',
-                help='Use testing API calls'
-            )),
             (['-n', '--not-live'], dict(
                 action='store_true',
                 help='Do not use live data API calls'
+            )),
+            (['--results-type'], dict(
+                action='store',
+                help='Specify results type. t for test, l for live, c for certified,\
+                    b to automatically switch from live to certified.',
+                default='l'
             )),
             (['-d', '--data-file'], dict(
                 action='store',

--- a/elex/cli/hooks.py
+++ b/elex/cli/hooks.py
@@ -9,7 +9,7 @@ def add_election_hook(app):
     Cache election API object reference after parsing args.
     """
     app.election = Election(
-        testresults=app.pargs.test,
+        resultstype=app.pargs.results_type,
         liveresults=not app.pargs.not_live,
         resultslevel=app.pargs.results_level,
         setzerocounts=app.pargs.set_zero_counts,

--- a/elex/cli/hooks.py
+++ b/elex/cli/hooks.py
@@ -9,8 +9,8 @@ def add_election_hook(app):
     Cache election API object reference after parsing args.
     """
     app.election = Election(
-        testresults=app.pargs.test,
         liveresults=not app.pargs.not_live,
+        resultstype=app.pargs.results_type,
         resultslevel=app.pargs.results_level,
         setzerocounts=app.pargs.set_zero_counts,
         is_test=False,

--- a/elex/cli/hooks.py
+++ b/elex/cli/hooks.py
@@ -9,8 +9,8 @@ def add_election_hook(app):
     Cache election API object reference after parsing args.
     """
     app.election = Election(
+        testresults=app.pargs.test,
         liveresults=not app.pargs.not_live,
-        resultstype=app.pargs.results_type,
         resultslevel=app.pargs.results_level,
         setzerocounts=app.pargs.set_zero_counts,
         is_test=False,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,0 @@
-Sphinx==1.5.6
-sphinx-rtd-theme==0.1.9
-
-nose2
-tox
-flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-CacheControl==0.12.*
-cement==2.10.2
-lockfile==0.12.2
-pymongo==3.3
-python-dateutil==2.7.*
-requests==2.20.*
-ujson==5.2.0

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,9 @@ setup(
         "CacheControl==0.12.*",
         "cement==2.10.2",
         "lockfile==0.12.2",
-        "pymongo==3.3",
+        "pymongo==4.1",
         "python-dateutil==2.7.*",
-        "requests==2.20.*",
+        "requests==2.28.*",
         "ujson==5.2.0",
     ],
     classifiers=[

--- a/tests/test_ap_network.py
+++ b/tests/test_ap_network.py
@@ -20,7 +20,7 @@ class APNetworkTestCase(NetworkTestCase):
         response = error.exception.response
         if response.status_code == 403:
             self.skipTest('over quota limit')
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 400)
 
     @unittest.skipUnless(os.environ.get('AP_API_KEY', None), API_MESSAGE)
     def test_nonexistent_date(self):

--- a/tests/test_candidate_reporting_unit.py
+++ b/tests/test_candidate_reporting_unit.py
@@ -251,6 +251,7 @@ class TestCandidateReportingUnit(tests.ElectionResultsTestCase):
                 'statename',
                 'statepostal',
                 'test',
+                'resultstype',
                 'uncontested',
                 'votecount',
                 'votepct',

--- a/tests/test_candidate_reporting_unit.py
+++ b/tests/test_candidate_reporting_unit.py
@@ -243,6 +243,7 @@ class TestCandidateReportingUnit(tests.ElectionResultsTestCase):
                 'precinctsreporting',
                 'precinctsreportingpct',
                 'precinctstotal',
+                'eevp',
                 'reportingunitid',
                 'reportingunitname',
                 'runoff',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -152,7 +152,7 @@ class ElexCLICSVTestCase(
         )
         self.assertEqual(
             fields,
-            ['id', 'electiondate', 'liveresults', 'testresults']
+            ['id', 'electiondate', 'liveresults', 'testresults', 'resultstype']
         )
 
     def test_csv_elections_length(self):
@@ -191,7 +191,7 @@ class ElexCLICSVTestCase(
         )
         self.assertEqual(
             fields,
-            ['id', 'electiondate', 'liveresults', 'testresults']
+            ['id', 'electiondate', 'liveresults', 'testresults', 'resultstype']
         )
 
     def test_csv_next_election_length(self):
@@ -424,7 +424,7 @@ class ElexCLIJSONTestCase(
         )
         self.assertEqual(
             fields,
-            ['id', 'electiondate', 'liveresults', 'testresults']
+            ['id', 'electiondate', 'liveresults', 'testresults', 'resultstype']
         )
 
     def test_json_elections_length(self):
@@ -463,7 +463,7 @@ class ElexCLIJSONTestCase(
         )
         self.assertEqual(
             fields,
-            ['id', 'electiondate', 'liveresults', 'testresults']
+            ['id', 'electiondate', 'liveresults', 'testresults', 'resultstype']
         )
 
     def test_json_next_election_length(self):


### PR DESCRIPTION
Adds support for the `resultstype` parameter, which is now required for test results in the AP API. Since `resultstype` is incompatible with the `test` parameter, that has been removed from the API calls. But `test` is still available and correct in the response.